### PR TITLE
fix #113 findOrCreateSpotFromId で spotTitle がない状態で、getWikipediaImageF…

### DIFF
--- a/functions/src/v1/lib/wikipedia.ts
+++ b/functions/src/v1/lib/wikipedia.ts
@@ -25,6 +25,7 @@ export const getWikipediaImageFromKgid = async (
 		itemListElement: {
 			result: {
 				detailedDescription?: { url?: string };
+				name?: string;
 			};
 		}[];
 	}>({
@@ -38,7 +39,7 @@ export const getWikipediaImageFromKgid = async (
 
 	const articleUrl = kgResponse?.itemListElement?.[0]?.result?.detailedDescription?.url;
 	if (!articleUrl) {
-		return { imageUrl: null, title: null };
+		return { imageUrl: null, title: kgResponse?.itemListElement?.[0]?.result?.name ?? null };
 	}
 
 	// Wikipedia URL からタイトルを抽出


### PR DESCRIPTION
…romKgid を呼び出した場合、kgResponse に title が無ければ失敗となる

return Wikipedia title when article URL is not available