### PR TITLE
Update navigation and camera screen

### DIFF
--- a/app-expo/app/[locale]/SpotCapture/index.tsx
+++ b/app-expo/app/[locale]/SpotCapture/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { View, ActivityIndicator, StyleSheet, Platform, Linking, TouchableOpacity } from "react-native";
 import { CameraType, CameraView, FlashMode, useCameraPermissions } from "expo-camera";
 import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
@@ -14,7 +14,7 @@ import { convertSupabaseToPrisma_ExtSpots } from "@shared/converters/convert_ext
 import i18n from "@/lib/i18n";
 import { serializeSpotGuideParams } from "@/utils/navigation";
 import { useDialog } from "@/contexts/DialogProvider";
-import { Button } from "react-native-paper";
+import { Button, IconButton } from "react-native-paper";
 import {
 	GestureEvent,
 	PinchGestureHandler,
@@ -128,6 +128,17 @@ export default function SpotCapture() {
 		}
 	});
 
+	/**
+	 * ❌ カメラ画面を閉じ、地図選択へ戻す
+	 *   - ユーザーが撮影を途中でやめたい場合の導線を確保するため
+	 */
+	const handleClose = useCallback(() => {
+		router.replace({
+			pathname: "/[locale]/PlaceMapSelect",
+			params: { locale: i18n.locale },
+		});
+	}, [router]);
+
 	const onPinchGestureEvent = (event: GestureEvent<PinchGestureHandlerEventPayload>) => {
 		const { scale, state } = event.nativeEvent;
 
@@ -189,6 +200,14 @@ export default function SpotCapture() {
 					flash={flash}
 				/>
 			</PinchGestureHandler>
+			<IconButton
+				icon="close"
+				size={24}
+				iconColor="white"
+				style={styles.closeButton}
+				onPress={handleClose}
+				testID="close-button"
+			/>
 			<View style={styles.controls}>
 				<TouchableOpacity onPress={() => setFacing(facing === "back" ? "front" : "back")} style={styles.iconButton}>
 					<Ionicons name="camera-reverse" size={24} color="white" />
@@ -273,6 +292,12 @@ const styles = StyleSheet.create({
 		right: 20,
 		flexDirection: "column",
 		gap: 16,
+	},
+	closeButton: {
+		position: "absolute",
+		top: 20,
+		right: 20,
+		backgroundColor: "rgba(0,0,0,0.5)",
 	},
 	iconButton: {
 		backgroundColor: "rgba(0,0,0,0.5)",

--- a/app-expo/app/[locale]/_layout.tsx
+++ b/app-expo/app/[locale]/_layout.tsx
@@ -60,7 +60,7 @@ export default function LocalLayout() {
 					<DialogProvider>
 						<AuthProvider>
 							<SplashHandler>
-								<Stack initialRouteName="SpotCapture/index" screenOptions={{ headerShown: false }} />
+								<Stack initialRouteName="PlaceMapSelect/index" screenOptions={{ headerShown: false }} />
 							</SplashHandler>
 						</AuthProvider>
 					</DialogProvider>


### PR DESCRIPTION
## Summary
- set `PlaceMapSelect` as the default screen
- add a close button to `SpotCapture`

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685cc70fb150832b99857db08940e3bc