### PR TITLE
Add visual character limit with comments

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/CustomQueryModal.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CustomQueryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { View, StyleSheet } from "react-native";
 import { Portal, Modal, Text, TextInput, Button, IconButton } from "react-native-paper";
 import i18n from "@/lib/i18n";
@@ -18,7 +18,39 @@ type CustomQueryModalProps = {
 };
 
 export const CustomQueryModal: React.FC<CustomQueryModalProps> = ({ visible, onDismiss, onSubmit, loading }) => {
-	const [query, setQuery] = useState("");
+       const [query, setQuery] = useState("");
+
+       // Cloud Function 側で処理できる文字数の上限（全角 35 文字相当）
+       const MAX_VISUAL_LENGTH = 70;
+
+       const getVisualLength = useCallback(
+               (text: string) =>
+                       // 半角1、全角2として見た目の文字数を計算する
+                       Array.from(text).reduce(
+                               (len, ch) => len + (/[\u0020-\u007E]/.test(ch) ? 1 : 2),
+                               0,
+                       ),
+               [],
+       );
+
+       const handleChangeText = useCallback(
+               (text: string) => {
+                       // 入力途中で上限を超えた分を即座に切り捨てる
+                       let len = 0;
+                       let result = "";
+                       for (const ch of Array.from(text)) {
+                               const charLen = /[\u0020-\u007E]/.test(ch) ? 1 : 2;
+                               if (len + charLen > MAX_VISUAL_LENGTH) break;
+                               result += ch;
+                               len += charLen;
+                       }
+                       setQuery(result);
+               },
+               [setQuery],
+       );
+
+       // カウンター表示用に見た目の文字数をメモ化して保持
+       const queryLength = useMemo(() => getVisualLength(query), [query, getVisualLength]);
 
 	/**
 	 * ✅ 入力された質問を送信
@@ -59,15 +91,18 @@ export const CustomQueryModal: React.FC<CustomQueryModalProps> = ({ visible, onD
 
 				<TextInput
 					label={i18n.t("PlaceGuide.customQueryPlaceholder")}
-					value={query}
-					onChangeText={setQuery}
-					mode="outlined"
-					multiline
-					numberOfLines={4}
-					style={styles.textInput}
-					disabled={loading}
-					testID="custom-query-input"
-				/>
+                                       value={query}
+                                       onChangeText={handleChangeText}
+                                       mode="outlined"
+                                       multiline
+                                       numberOfLines={4}
+                                       style={styles.textInput}
+                                       disabled={loading}
+                                       testID="custom-query-input"
+                               />
+
+                               {/* 現在の入力長をユーザーに示す */}
+                               <Text style={styles.charCounter}>{`${queryLength} / ${MAX_VISUAL_LENGTH}`}</Text>
 
 				<View style={styles.buttonContainer}>
 					<Button
@@ -124,14 +159,20 @@ const styles = StyleSheet.create({
 		backgroundColor: "#f5f5f5",
 		borderRadius: 20,
 	},
-	textInput: {
-		marginBottom: 24,
-		backgroundColor: "#fafafa",
-	},
-	buttonContainer: {
-		flexDirection: "row",
-		gap: 12,
-	},
+        textInput: {
+                marginBottom: 24,
+                backgroundColor: "#fafafa",
+        },
+       charCounter: {
+               alignSelf: "flex-end",
+               marginBottom: 12,
+               color: "#777",
+               fontSize: 12,
+       },
+        buttonContainer: {
+                flexDirection: "row",
+                gap: 12,
+        },
 	cancelButton: {
 		flex: 1,
 		borderColor: "#e0e0e0",


### PR DESCRIPTION
## Summary
- refine custom query text limiter with comments explaining necessity
- show input length counter using new MAX_VISUAL_LENGTH constant

## Testing
- `pnpm format` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm --filter app-expo test` *(fails: Request was cancelled)*


------
https://chatgpt.com/codex/tasks/task_e_685cc7ab39cc832b8266b298a1cff0d7