### PR TITLE
Implement Google Places search workflow

### DIFF
--- a/app-expo/app/[locale]/PlaceMapSelect/index.tsx
+++ b/app-expo/app/[locale]/PlaceMapSelect/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, ComponentRef } from "react";
-import { View, StyleSheet, Platform, Dimensions } from "react-native";
+import { View, StyleSheet, Platform, Dimensions, FlatList } from "react-native";
 import { useRouter } from "expo-router";
-import { Text, Button, IconButton, Searchbar } from "react-native-paper";
+import { Text, Button, IconButton, Searchbar, List } from "react-native-paper";
 import MapView, { Marker, Region } from "@/components/MapView";
 import * as Location from "expo-location";
 
@@ -45,6 +45,7 @@ export default function MapScreen() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [isSearchExpanded, setIsSearchExpanded] = useState(false);
 	const [isSearching, setIsSearching] = useState(false);
+	const [predictions, setPredictions] = useState<MapLocation[]>([]);
 	const mapRef = useRef<ComponentRef<typeof MapView> | null>(null);
 
 	// Initialize with user's current location
@@ -98,7 +99,8 @@ export default function MapScreen() {
 	/**
 	 * 🔎 地名検索を実行
 	 *
-	 * - Google Places Autocomplete (new) APIを使用して検索
+	 * - APIキーを保持しないため、Cloud Functions 経由でプレイス候補を取得
+	 * - 検索結果は選択時まで確定しないため、地点状態はここでは更新しない
 	 */
 	const handleSearch = useCallback(async () => {
 		if (!searchQuery.trim()) return;
@@ -111,7 +113,18 @@ export default function MapScreen() {
 				payload: { query: searchQuery },
 			});
 
-			setSelectedLocation({});
+			type PlacesAutocompleteRequest = { input: string };
+			type PlacesAutocompleteResponse = {
+				predictions: MapLocation[];
+			};
+
+			const { predictions } = await callCloudFunction<PlacesAutocompleteRequest, PlacesAutocompleteResponse>(
+				"googlePlacesAutocomplete",
+				{ input: searchQuery },
+				"v1",
+			);
+
+			setPredictions(predictions);
 		} catch (error: any) {
 			logFrontendEvent({
 				event_name: "mapSearchFailed",
@@ -121,23 +134,90 @@ export default function MapScreen() {
 		} finally {
 			setIsSearching(false);
 		}
-	}, [searchQuery, logFrontendEvent]);
+	}, [searchQuery, logFrontendEvent, callCloudFunction]);
 
 	/**
 	 * 🗺️ 地図ピン押下した場合
 	 *
-	 * - Google Places Details (New) APIを使用して地点情報を取得
+	 * - MapView からは placeId しか得られないため、Cloud Functions で詳細座標を取得
 	 */
 	const handlePoiPress = useCallback(
-		(event: any) => {
-			const { placeId, coordinate } = event.nativeEvent;
+		async (event: any) => {
+			const { placeId } = event.nativeEvent;
+			if (!placeId) return;
 
-			setSelectedLocation({});
+			try {
+				type PlaceDetailsRequest = { placeId: string };
+				type PlaceDetailsResponse = {
+					placeId: string;
+					name: string;
+					latitude: number;
+					longitude: number;
+				};
+
+				const place = await callCloudFunction<PlaceDetailsRequest, PlaceDetailsResponse>(
+					"googlePlacesDetails",
+					{ placeId },
+					"v1",
+				);
+
+				const newRegion: Region = {
+					latitude: place.latitude,
+					longitude: place.longitude,
+					latitudeDelta: 0.002,
+					longitudeDelta: 0.002,
+				};
+				setRegion(newRegion);
+				mapRef.current?.animateToRegion(newRegion, 1000);
+
+				setSelectedLocation({
+					placeId: place.placeId,
+					name: place.name,
+					latitude: place.latitude,
+					longitude: place.longitude,
+				});
+
+				logFrontendEvent({
+					event_name: "mapLocationSelected",
+					error_level: "info",
+					payload: { placeId },
+				});
+			} catch (error: any) {
+				logFrontendEvent({
+					event_name: "mapLocationSelectFailed",
+					error_level: "error",
+					payload: { error: error.message, placeId },
+				});
+			}
+		},
+		[logFrontendEvent, callCloudFunction],
+	);
+
+	/**
+	 * 📑 オートコンプリート候補を選択したときの処理
+	 *
+	 * - 候補の緯度経度へ地図を移動し、次画面遷移のため選択状態を保持
+	 */
+	// 検索結果をユーザーが選択したタイミングで地点を確定させる
+	const handlePredictionSelect = useCallback(
+		(location: MapLocation) => {
+			const newRegion: Region = {
+				latitude: location.latitude,
+				longitude: location.longitude,
+				latitudeDelta: 0.002,
+				longitudeDelta: 0.002,
+			};
+			setRegion(newRegion);
+			mapRef.current?.animateToRegion(newRegion, 1000);
+
+			setSelectedLocation(location);
+			setIsSearchExpanded(false);
+			setPredictions([]);
 
 			logFrontendEvent({
-				event_name: "mapLocationSelected",
+				event_name: "mapLocationSelectedFromSearch",
 				error_level: "info",
-				payload: { location },
+				payload: { placeId: location.placeId },
 			});
 		},
 		[logFrontendEvent],
@@ -178,7 +258,9 @@ export default function MapScreen() {
 	 * 🔍 検索ボックス押下時に検索UIを展開
 	 */
 	const handleSearchBoxPress = useCallback(() => {
+		// ユーザーに入力欄を広げるため展開。前回の候補はクリアする
 		setIsSearchExpanded(true);
+		setPredictions([]);
 	}, []);
 
 	/**
@@ -187,6 +269,7 @@ export default function MapScreen() {
 	const handleSearchCollapse = useCallback(() => {
 		setIsSearchExpanded(false);
 		setSearchQuery("");
+		setPredictions([]);
 	}, []);
 
 	return (
@@ -266,6 +349,14 @@ export default function MapScreen() {
 								style={styles.expandedSearchBar}
 								inputStyle={styles.searchInput}
 								testID="expanded-search-bar"
+							/>
+							<FlatList
+								data={predictions}
+								keyExtractor={(item) => item.placeId}
+								renderItem={({ item }) => (
+									<List.Item title={item.name} onPress={() => handlePredictionSelect(item)} testID="prediction-item" />
+								)}
+								style={styles.predictionsList}
 							/>
 						</View>
 					) : (
@@ -444,6 +535,9 @@ const styles = StyleSheet.create({
 	},
 	searchInput: {
 		fontSize: 16,
+	},
+	predictionsList: {
+		flex: 1,
 	},
 	instructionText: {
 		textAlign: "center",

--- a/app-expo/app/[locale]/PlaceMapSelect/index.tsx
+++ b/app-expo/app/[locale]/PlaceMapSelect/index.tsx
@@ -10,6 +10,11 @@ import { useLocale } from "@/hooks/useLocale";
 import { useWithLoading } from "@/hooks/useWithLoading";
 import i18n from "@/lib/i18n";
 import { useCloudFunction } from "@/hooks/useCloudFunction";
+import type {
+       PlacesAutocompleteRequest,
+       PlacesAutocompleteResponse,
+} from "@shared/api/googlePlacesAutocomplete.schema";
+import type { PlacesDetailsRequest, PlacesDetailsResponse } from "@shared/api/googlePlacesDetails.schema";
 
 type MapLocation = {
 	placeId: string;
@@ -113,16 +118,11 @@ export default function MapScreen() {
 				payload: { query: searchQuery },
 			});
 
-			type PlacesAutocompleteRequest = { input: string };
-			type PlacesAutocompleteResponse = {
-				predictions: MapLocation[];
-			};
-
-			const { predictions } = await callCloudFunction<PlacesAutocompleteRequest, PlacesAutocompleteResponse>(
-				"googlePlacesAutocomplete",
-				{ input: searchQuery },
-				"v1",
-			);
+                       const { predictions } = await callCloudFunction<PlacesAutocompleteRequest, PlacesAutocompleteResponse>(
+                               "googlePlacesAutocomplete",
+                               { input: searchQuery },
+                               "v1",
+                       );
 
 			setPredictions(predictions);
 		} catch (error: any) {
@@ -146,20 +146,12 @@ export default function MapScreen() {
 			const { placeId } = event.nativeEvent;
 			if (!placeId) return;
 
-			try {
-				type PlaceDetailsRequest = { placeId: string };
-				type PlaceDetailsResponse = {
-					placeId: string;
-					name: string;
-					latitude: number;
-					longitude: number;
-				};
-
-				const place = await callCloudFunction<PlaceDetailsRequest, PlaceDetailsResponse>(
-					"googlePlacesDetails",
-					{ placeId },
-					"v1",
-				);
+                       try {
+                               const place = await callCloudFunction<PlacesDetailsRequest, PlacesDetailsResponse>(
+                                       "googlePlacesDetails",
+                                       { placeId },
+                                       "v1",
+                               );
 
 				const newRegion: Region = {
 					latitude: place.latitude,
@@ -350,14 +342,22 @@ export default function MapScreen() {
 								inputStyle={styles.searchInput}
 								testID="expanded-search-bar"
 							/>
-							<FlatList
-								data={predictions}
-								keyExtractor={(item) => item.placeId}
-								renderItem={({ item }) => (
-									<List.Item title={item.name} onPress={() => handlePredictionSelect(item)} testID="prediction-item" />
-								)}
-								style={styles.predictionsList}
-							/>
+                                                       <FlatList
+                                                               data={predictions}
+                                                               keyExtractor={(item) => item.placeId}
+                                                               renderItem={({ item }) => (
+                                                                       <List.Item
+                                                                               title={item.name}
+                                                                               onPress={() => handlePredictionSelect(item)}
+                                                                               style={styles.predictionItem}
+                                                                               titleStyle={styles.predictionTitle}
+                                                                               testID="prediction-item"
+                                                                       />
+                                                               )}
+                                                               ItemSeparatorComponent={() => <View style={styles.predictionSeparator} />}
+                                                               contentContainerStyle={styles.predictionsContent}
+                                                               style={styles.predictionsList}
+                                                       />
 						</View>
 					) : (
 						// Collapsed Bottom Sheet UI
@@ -536,9 +536,24 @@ const styles = StyleSheet.create({
 	searchInput: {
 		fontSize: 16,
 	},
-	predictionsList: {
-		flex: 1,
-	},
+        predictionsList: {
+                flex: 1,
+        },
+       predictionsContent: {
+               paddingVertical: 8,
+       },
+       predictionItem: {
+               backgroundColor: "#fff",
+               paddingVertical: 8,
+       },
+       predictionTitle: {
+               fontSize: 16,
+       },
+       predictionSeparator: {
+               height: StyleSheet.hairlineWidth,
+               backgroundColor: "#e5e5e5",
+               marginLeft: 16,
+       },
 	instructionText: {
 		textAlign: "center",
 		color: "#666",

--- a/functions/src/v1/index.ts
+++ b/functions/src/v1/index.ts
@@ -5,3 +5,5 @@ export { generateSpotGuide } from "./routes/generateSpotGuide";
 export { listRecommendedSpotsByVisitHistory } from "./routes/listRecommendedSpotsByVisitHistory";
 export { listSpotGuides } from "./routes/listSpotGuides";
 export { pingDb } from "./routes/pingDb";
+export { googlePlacesAutocomplete } from "./routes/googlePlacesAutocomplete";
+export { googlePlacesDetails } from "./routes/googlePlacesDetails";

--- a/functions/src/v1/routes/googlePlacesAutocomplete.ts
+++ b/functions/src/v1/routes/googlePlacesAutocomplete.ts
@@ -1,0 +1,36 @@
+import { withValidatedAuthHandler } from "../lib/handler";
+import { logBackendEvent } from "../lib/logger";
+import {
+	googlePlacesAutocompleteRequestSchema,
+	GooglePlacesAutocompleteResponse,
+} from "../../../../shared/api/googlePlacesAutocomplete.schema";
+import { fetchAutocompletePredictions, fetchPlaceDetails } from "../services/googlePlaces";
+
+/**
+ * 🔎 ユーザー入力から候補地点を検索する Cloud Function
+ *
+ * - フロントエンドでは API キーを保持しないため、サーバー側で代理リクエストを行う
+ * - 取得した候補には緯度経度を付与して返却する
+ */
+export const googlePlacesAutocomplete = withValidatedAuthHandler(
+	googlePlacesAutocompleteRequestSchema,
+	async function googlePlacesAutocomplete({ res, input, requestId, userId, functionName }) {
+		const predictions = await fetchAutocompletePredictions(input.input, requestId, userId);
+		const detailed = await Promise.all(
+			predictions.slice(0, 5).map((p) => fetchPlaceDetails(p.placeId, requestId, userId)),
+		);
+
+		const response: GooglePlacesAutocompleteResponse = { predictions: detailed };
+
+		logBackendEvent({
+			event_name: "googlePlacesAutocompleteSuccess",
+			error_level: "info",
+			function_name: functionName,
+			user_id: userId,
+			request_id: requestId,
+			payload: { query: input.input, count: detailed.length },
+		});
+
+		res.status(200).json(response);
+	},
+);

--- a/functions/src/v1/routes/googlePlacesAutocomplete.ts
+++ b/functions/src/v1/routes/googlePlacesAutocomplete.ts
@@ -1,8 +1,8 @@
 import { withValidatedAuthHandler } from "../lib/handler";
 import { logBackendEvent } from "../lib/logger";
 import {
-	googlePlacesAutocompleteRequestSchema,
-	GooglePlacesAutocompleteResponse,
+       googlePlacesAutocompleteRequestSchema,
+       PlacesAutocompleteResponse,
 } from "../../../../shared/api/googlePlacesAutocomplete.schema";
 import { fetchAutocompletePredictions, fetchPlaceDetails } from "../services/googlePlaces";
 
@@ -20,7 +20,7 @@ export const googlePlacesAutocomplete = withValidatedAuthHandler(
 			predictions.slice(0, 5).map((p) => fetchPlaceDetails(p.placeId, requestId, userId)),
 		);
 
-		const response: GooglePlacesAutocompleteResponse = { predictions: detailed };
+               const response: PlacesAutocompleteResponse = { predictions: detailed };
 
 		logBackendEvent({
 			event_name: "googlePlacesAutocompleteSuccess",

--- a/functions/src/v1/routes/googlePlacesDetails.ts
+++ b/functions/src/v1/routes/googlePlacesDetails.ts
@@ -1,0 +1,32 @@
+import { withValidatedAuthHandler } from "../lib/handler";
+import { logBackendEvent } from "../lib/logger";
+import {
+	googlePlacesDetailsRequestSchema,
+	GooglePlacesDetailsResponse,
+} from "../../../../shared/api/googlePlacesDetails.schema";
+import { fetchPlaceDetails } from "../services/googlePlaces";
+
+/**
+ * 📍 地図上の POI 押下時に詳細情報を取得する Cloud Function
+ *
+ * - MapView からは placeId のみ得られるため、緯度経度を取得してフロントへ返す
+ */
+export const googlePlacesDetails = withValidatedAuthHandler(
+	googlePlacesDetailsRequestSchema,
+	async function googlePlacesDetails({ res, input, requestId, userId, functionName }) {
+		const detail = await fetchPlaceDetails(input.placeId, requestId, userId);
+
+		const response: GooglePlacesDetailsResponse = detail;
+
+		logBackendEvent({
+			event_name: "googlePlacesDetailsSuccess",
+			error_level: "info",
+			function_name: functionName,
+			user_id: userId,
+			request_id: requestId,
+			payload: { placeId: input.placeId },
+		});
+
+		res.status(200).json(response);
+	},
+);

--- a/functions/src/v1/routes/googlePlacesDetails.ts
+++ b/functions/src/v1/routes/googlePlacesDetails.ts
@@ -1,8 +1,8 @@
 import { withValidatedAuthHandler } from "../lib/handler";
 import { logBackendEvent } from "../lib/logger";
 import {
-	googlePlacesDetailsRequestSchema,
-	GooglePlacesDetailsResponse,
+       googlePlacesDetailsRequestSchema,
+       PlacesDetailsResponse,
 } from "../../../../shared/api/googlePlacesDetails.schema";
 import { fetchPlaceDetails } from "../services/googlePlaces";
 
@@ -16,7 +16,7 @@ export const googlePlacesDetails = withValidatedAuthHandler(
 	async function googlePlacesDetails({ res, input, requestId, userId, functionName }) {
 		const detail = await fetchPlaceDetails(input.placeId, requestId, userId);
 
-		const response: GooglePlacesDetailsResponse = detail;
+               const response: PlacesDetailsResponse = detail;
 
 		logBackendEvent({
 			event_name: "googlePlacesDetailsSuccess",

--- a/functions/src/v1/services/googlePlaces.ts
+++ b/functions/src/v1/services/googlePlaces.ts
@@ -1,53 +1,89 @@
+import { PlacesApiClient } from "@googlemaps/places";
 import { env } from "../lib/env";
-import { callExternalApi } from "../lib/backendUtils";
+import { logExternalApi } from "../lib/logger";
 
-/** Google Places Autocomplete(New) を呼び出して候補を取得する */
+const client = new PlacesApiClient({ key: env.FUNCTIONS_GOOGLE_PLACE_API_KEY });
+
+/**
+ * 🔍 Google Places Autocomplete(New)
+ *
+ * サーバー側から呼び出してAPIキーを隠蔽しつつログを残す。
+ */
 export const fetchAutocompletePredictions = async (
-	input: string,
-	requestId: string,
-	userId: string,
+        input: string,
+        requestId: string,
+        userId: string,
 ): Promise<{ placeId: string; text: string }[]> => {
-	const endpoint = `https://places.googleapis.com/v1/places:autocomplete?input=${encodeURIComponent(
-		input,
-	)}&languageCode=ja&key=${env.FUNCTIONS_GOOGLE_PLACE_API_KEY}`;
-
-	const response = await callExternalApi<{ predictions: { placeId: string; text: string }[] }>({
-		requestId,
-		functionName: "fetchAutocompletePredictions",
-		apiName: "GooglePlacesAPI",
-		endpoint,
-		method: "GET",
-		userId,
-	});
-
-	return response.predictions || [];
+        const start = Date.now();
+        let status = 0;
+        let payload: any = null;
+        let errorMessage: string | null = null;
+        try {
+                const response = await client.autocomplete({ input, languageCode: "ja" });
+                payload = response;
+                status = 200;
+                return (
+                        response.predictions?.map((p) => ({ placeId: p.placeId ?? "", text: p.text ?? "" })) || []
+                );
+        } catch (error: any) {
+                errorMessage = error.message;
+                status = error.code || 500;
+                throw new Error(`Places autocomplete failed: ${errorMessage}`);
+        } finally {
+                logExternalApi({
+                        request_id: requestId,
+                        function_name: "fetchAutocompletePredictions",
+                        api_name: "GooglePlaces",
+                        endpoint: "autocomplete",
+                        request_payload: JSON.stringify({ input }),
+                        response_payload: JSON.stringify(payload),
+                        status_code: status,
+                        error_message: errorMessage,
+                        response_time_ms: Date.now() - start,
+                        user_id: userId,
+                });
+        }
 };
 
-/** Place ID から名前と緯度経度を取得する */
+/**
+ * 📍 Place ID から詳細座標を取得
+ */
 export const fetchPlaceDetails = async (
-	placeId: string,
-	requestId: string,
-	userId: string,
+        placeId: string,
+        requestId: string,
+        userId: string,
 ): Promise<{ placeId: string; name: string; latitude: number; longitude: number }> => {
-	const endpoint = `https://places.googleapis.com/v1/${placeId}?fields=location,displayName&key=${env.FUNCTIONS_GOOGLE_PLACE_API_KEY}`;
-
-	const response = await callExternalApi<{
-		id: string;
-		location?: { latitude: number; longitude: number };
-		displayName?: { text: string };
-	}>({
-		requestId,
-		functionName: "fetchPlaceDetails",
-		apiName: "GooglePlacesAPI",
-		endpoint,
-		method: "GET",
-		userId,
-	});
-
-	return {
-		placeId: response.id,
-		name: response.displayName?.text ?? "",
-		latitude: response.location?.latitude ?? 0,
-		longitude: response.location?.longitude ?? 0,
-	};
+        const start = Date.now();
+        let status = 0;
+        let payload: any = null;
+        let errorMessage: string | null = null;
+        try {
+                const response = await client.place({ name: placeId, languageCode: "ja", fields: ["id", "displayName", "location"] });
+                payload = response;
+                status = 200;
+                return {
+                        placeId: response.id,
+                        name: response.displayName?.text ?? "",
+                        latitude: response.location?.latitude ?? 0,
+                        longitude: response.location?.longitude ?? 0,
+                };
+        } catch (error: any) {
+                errorMessage = error.message;
+                status = error.code || 500;
+                throw new Error(`Places details failed: ${errorMessage}`);
+        } finally {
+                logExternalApi({
+                        request_id: requestId,
+                        function_name: "fetchPlaceDetails",
+                        api_name: "GooglePlaces",
+                        endpoint: "place",
+                        request_payload: JSON.stringify({ placeId }),
+                        response_payload: JSON.stringify(payload),
+                        status_code: status,
+                        error_message: errorMessage,
+                        response_time_ms: Date.now() - start,
+                        user_id: userId,
+                });
+        }
 };
+

--- a/functions/src/v1/services/googlePlaces.ts
+++ b/functions/src/v1/services/googlePlaces.ts
@@ -1,0 +1,53 @@
+import { env } from "../lib/env";
+import { callExternalApi } from "../lib/backendUtils";
+
+/** Google Places Autocomplete(New) を呼び出して候補を取得する */
+export const fetchAutocompletePredictions = async (
+	input: string,
+	requestId: string,
+	userId: string,
+): Promise<{ placeId: string; text: string }[]> => {
+	const endpoint = `https://places.googleapis.com/v1/places:autocomplete?input=${encodeURIComponent(
+		input,
+	)}&languageCode=ja&key=${env.FUNCTIONS_GOOGLE_PLACE_API_KEY}`;
+
+	const response = await callExternalApi<{ predictions: { placeId: string; text: string }[] }>({
+		requestId,
+		functionName: "fetchAutocompletePredictions",
+		apiName: "GooglePlacesAPI",
+		endpoint,
+		method: "GET",
+		userId,
+	});
+
+	return response.predictions || [];
+};
+
+/** Place ID から名前と緯度経度を取得する */
+export const fetchPlaceDetails = async (
+	placeId: string,
+	requestId: string,
+	userId: string,
+): Promise<{ placeId: string; name: string; latitude: number; longitude: number }> => {
+	const endpoint = `https://places.googleapis.com/v1/${placeId}?fields=location,displayName&key=${env.FUNCTIONS_GOOGLE_PLACE_API_KEY}`;
+
+	const response = await callExternalApi<{
+		id: string;
+		location?: { latitude: number; longitude: number };
+		displayName?: { text: string };
+	}>({
+		requestId,
+		functionName: "fetchPlaceDetails",
+		apiName: "GooglePlacesAPI",
+		endpoint,
+		method: "GET",
+		userId,
+	});
+
+	return {
+		placeId: response.id,
+		name: response.displayName?.text ?? "",
+		latitude: response.location?.latitude ?? 0,
+		longitude: response.location?.longitude ?? 0,
+	};
+};

--- a/shared/api/googlePlacesAutocomplete.schema.ts
+++ b/shared/api/googlePlacesAutocomplete.schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * 📝 googlePlacesAutocomplete API のリクエストスキーマ
+ *
+ * - 入力キーワードを元に Google Places Autocomplete(New) を実行
+ */
+export const googlePlacesAutocompleteRequestSchema = z.object({
+	input: z.string().min(1, "input is required"),
+});
+
+/**
+ * googlePlacesAutocomplete API のリクエスト型
+ */
+export type GooglePlacesAutocompleteRequest = z.infer<typeof googlePlacesAutocompleteRequestSchema>;
+
+/**
+ * googlePlacesAutocomplete API のレスポンス型
+ */
+export type GooglePlacesAutocompleteResponse = {
+	predictions: {
+		placeId: string;
+		name: string;
+		latitude: number;
+		longitude: number;
+	}[];
+};

--- a/shared/api/googlePlacesAutocomplete.schema.ts
+++ b/shared/api/googlePlacesAutocomplete.schema.ts
@@ -12,12 +12,12 @@ export const googlePlacesAutocompleteRequestSchema = z.object({
 /**
  * googlePlacesAutocomplete API のリクエスト型
  */
-export type GooglePlacesAutocompleteRequest = z.infer<typeof googlePlacesAutocompleteRequestSchema>;
+export type PlacesAutocompleteRequest = z.infer<typeof googlePlacesAutocompleteRequestSchema>;
 
 /**
  * googlePlacesAutocomplete API のレスポンス型
  */
-export type GooglePlacesAutocompleteResponse = {
+export type PlacesAutocompleteResponse = {
 	predictions: {
 		placeId: string;
 		name: string;

--- a/shared/api/googlePlacesDetails.schema.ts
+++ b/shared/api/googlePlacesDetails.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * 📝 googlePlacesDetails API のリクエストスキーマ
+ *
+ * - Place ID に基づき地点の詳細情報を取得
+ */
+export const googlePlacesDetailsRequestSchema = z.object({
+	placeId: z.string().min(1, "placeId is required"),
+});
+
+/**
+ * googlePlacesDetails API のリクエスト型
+ */
+export type GooglePlacesDetailsRequest = z.infer<typeof googlePlacesDetailsRequestSchema>;
+
+/**
+ * googlePlacesDetails API のレスポンス型
+ */
+export type GooglePlacesDetailsResponse = {
+	placeId: string;
+	name: string;
+	latitude: number;
+	longitude: number;
+};

--- a/shared/api/googlePlacesDetails.schema.ts
+++ b/shared/api/googlePlacesDetails.schema.ts
@@ -12,12 +12,12 @@ export const googlePlacesDetailsRequestSchema = z.object({
 /**
  * googlePlacesDetails API のリクエスト型
  */
-export type GooglePlacesDetailsRequest = z.infer<typeof googlePlacesDetailsRequestSchema>;
+export type PlacesDetailsRequest = z.infer<typeof googlePlacesDetailsRequestSchema>;
 
 /**
  * googlePlacesDetails API のレスポンス型
  */
-export type GooglePlacesDetailsResponse = {
+export type PlacesDetailsResponse = {
 	placeId: string;
 	name: string;
 	latitude: number;


### PR DESCRIPTION
## Summary
- wire map search to Google Places autocomplete via Cloud Functions
- fetch place details on POI press and when selecting search prediction
- expose new backend endpoints and API schemas

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685ccc575e44832ba44696e31a6f064d