### PR TITLE
Implement new guide generation endpoints

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -40,16 +40,16 @@ export const GUIDE_CATEGORIES = [
 		icon: "palette-outline",
 	},
 	{
-		id: "food",
-		label: "Food",
-		description: "famous foods and cuisine",
-		icon: "food-outline",
-	},
-	{
 		id: "architecture",
 		label: "Architecture",
 		description: "buildings and architectural style",
 		icon: "home-city-outline",
+	},
+	{
+		id: "food",
+		label: "Food",
+		description: "famous foods and cuisine",
+		icon: "food-outline",
 	},
 	{
 		id: "nature",

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -26,15 +26,55 @@ export type PlaceGuideCardProps = {
 	onBackPress: () => void;
 };
 
-const GUIDE_CATEGORIES = [
-	{ id: "history", label: "History", icon: "book-open-outline" },
-	{ id: "culture", label: "Culture", icon: "palette-outline" },
-	{ id: "food", label: "Food", icon: "food-outline" },
-	{ id: "architecture", label: "Architecture", icon: "home-city-outline" },
-	{ id: "nature", label: "Nature", icon: "leaf-outline" },
-	{ id: "people", label: "People", icon: "account-group-outline" },
-	{ id: "cost", label: "Cost", icon: "currency-usd" },
-	{ id: "safety", label: "Safety", icon: "shield-check-outline" },
+export const GUIDE_CATEGORIES = [
+        {
+                id: "history",
+                label: "History",
+                description: "historical background of the place",
+                icon: "book-open-outline",
+        },
+        {
+                id: "culture",
+                label: "Culture",
+                description: "local culture, art and traditions",
+                icon: "palette-outline",
+        },
+        {
+                id: "food",
+                label: "Food",
+                description: "famous foods and cuisine",
+                icon: "food-outline",
+        },
+        {
+                id: "architecture",
+                label: "Architecture",
+                description: "buildings and architectural style",
+                icon: "home-city-outline",
+        },
+        {
+                id: "nature",
+                label: "Nature",
+                description: "surrounding nature and scenery",
+                icon: "leaf-outline",
+        },
+        {
+                id: "people",
+                label: "People",
+                description: "local people and society",
+                icon: "account-group-outline",
+        },
+        {
+                id: "cost",
+                label: "Cost",
+                description: "typical expenses and prices",
+                icon: "currency-usd",
+        },
+        {
+                id: "safety",
+                label: "Safety",
+                description: "travel safety tips",
+                icon: "shield-check-outline",
+        },
 ];
 
 /**

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -27,54 +27,54 @@ export type PlaceGuideCardProps = {
 };
 
 export const GUIDE_CATEGORIES = [
-        {
-                id: "history",
-                label: "History",
-                description: "historical background of the place",
-                icon: "book-open-outline",
-        },
-        {
-                id: "culture",
-                label: "Culture",
-                description: "local culture, art and traditions",
-                icon: "palette-outline",
-        },
-        {
-                id: "food",
-                label: "Food",
-                description: "famous foods and cuisine",
-                icon: "food-outline",
-        },
-        {
-                id: "architecture",
-                label: "Architecture",
-                description: "buildings and architectural style",
-                icon: "home-city-outline",
-        },
-        {
-                id: "nature",
-                label: "Nature",
-                description: "surrounding nature and scenery",
-                icon: "leaf-outline",
-        },
-        {
-                id: "people",
-                label: "People",
-                description: "local people and society",
-                icon: "account-group-outline",
-        },
-        {
-                id: "cost",
-                label: "Cost",
-                description: "typical expenses and prices",
-                icon: "currency-usd",
-        },
-        {
-                id: "safety",
-                label: "Safety",
-                description: "travel safety tips",
-                icon: "shield-check-outline",
-        },
+	{
+		id: "history",
+		label: "History",
+		description: "historical background of the place",
+		icon: "book-open-outline",
+	},
+	{
+		id: "culture",
+		label: "Culture",
+		description: "local culture, art and traditions",
+		icon: "palette-outline",
+	},
+	{
+		id: "food",
+		label: "Food",
+		description: "famous foods and cuisine",
+		icon: "food-outline",
+	},
+	{
+		id: "architecture",
+		label: "Architecture",
+		description: "buildings and architectural style",
+		icon: "home-city-outline",
+	},
+	{
+		id: "nature",
+		label: "Nature",
+		description: "surrounding nature and scenery",
+		icon: "leaf-outline",
+	},
+	{
+		id: "people",
+		label: "People",
+		description: "local people and society",
+		icon: "account-group-outline",
+	},
+	{
+		id: "cost",
+		label: "Cost",
+		description: "typical expenses and prices",
+		icon: "currency-usd",
+	},
+	{
+		id: "safety",
+		label: "Safety",
+		description: "travel safety tips",
+		icon: "shield-check-outline",
+	},
 ];
 
 /**

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -13,20 +13,20 @@ import i18n from "@/lib/i18n";
 import { useCloudFunction } from "@/hooks/useCloudFunction";
 
 import type {
-        GenerateGeneralPlaceGuideRequest,
-        GenerateGeneralPlaceGuideResponse,
+	GenerateGeneralPlaceGuideRequest,
+	GenerateGeneralPlaceGuideResponse,
 } from "@shared/api/generateGeneralPlaceGuide.schema";
 import type {
-        GeneratePlaceGuideFromCategoryRequest,
-        GeneratePlaceGuideFromCategoryResponse,
+	GeneratePlaceGuideFromCategoryRequest,
+	GeneratePlaceGuideFromCategoryResponse,
 } from "@shared/api/generatePlaceGuideFromCategory.schema";
 import type {
-        GeneratePlaceGuideFromQuestionRequest,
-        GeneratePlaceGuideFromQuestionResponse,
+	GeneratePlaceGuideFromQuestionRequest,
+	GeneratePlaceGuideFromQuestionResponse,
 } from "@shared/api/generatePlaceGuideFromQuestion.schema";
 import type {
-        GenerateHighlightGuideFromQuestionRequest,
-        GenerateHighlightGuideFromQuestionResponse,
+	GenerateHighlightGuideFromQuestionRequest,
+	GenerateHighlightGuideFromQuestionResponse,
 } from "@shared/api/generateHighlightGuideFromQuestion.schema";
 
 import { PlaceGuideCard, PlaceGuide, GUIDE_CATEGORIES } from "./PlaceGuideCard";
@@ -36,13 +36,10 @@ import { PlaceGuideParams } from "@/types/navigation";
 
 const { width } = Dimensions.get("window");
 
-const CATEGORY_DESCRIPTION_MAP = GUIDE_CATEGORIES.reduce<Record<string, string>>(
-        (acc, c) => {
-                acc[c.id] = c.description;
-                return acc;
-        },
-        {},
-);
+const CATEGORY_DESCRIPTION_MAP = GUIDE_CATEGORIES.reduce<Record<string, string>>((acc, c) => {
+	acc[c.id] = c.description;
+	return acc;
+}, {});
 
 type PlaceData = {
 	id: string;
@@ -127,131 +124,131 @@ export default function PlaceScreen() {
 		}
 	};
 
-        const generatePlaceGuidesFromCategory = async (categoryId: string) => {
-                if (!placeData) return;
-                try {
-                        const description = CATEGORY_DESCRIPTION_MAP[categoryId] || categoryId;
-                        const { guide, audioUrl } = await callCloudFunction<
-                                GeneratePlaceGuideFromCategoryRequest,
-                                GeneratePlaceGuideFromCategoryResponse
-                        >(
-                                "generatePlaceGuideFromCategory",
-                                {
-                                        placeId: placeData.id,
-                                        placeName: placeData.name,
-                                        latitude: parseFloat(params.latitude),
-                                        longitude: parseFloat(params.longitude),
-                                        categoryDescription: description,
-                                        languageTag: locale,
-                                },
-                                "v1",
-                        );
+	const generatePlaceGuidesFromCategory = async (categoryId: string) => {
+		if (!placeData) return;
+		try {
+			const description = CATEGORY_DESCRIPTION_MAP[categoryId] || categoryId;
+			const { guide, audioUrl } = await callCloudFunction<
+				GeneratePlaceGuideFromCategoryRequest,
+				GeneratePlaceGuideFromCategoryResponse
+			>(
+				"generatePlaceGuideFromCategory",
+				{
+					placeId: placeData.id,
+					placeName: placeData.name,
+					latitude: parseFloat(params.latitude),
+					longitude: parseFloat(params.longitude),
+					categoryDescription: description,
+					languageTag: locale,
+				},
+				"v1",
+			);
 
-                        const newGuide: PlaceGuide = {
-                                id: guide.id,
-                                title: guide.title,
-                                content: guide.content,
-                                category: categoryId,
-                                audioUrl,
-                        };
-                        setPlaceGuides((prev) => [...prev, newGuide]);
-                } catch (err: any) {
-                        logFrontendEvent({
-                                event_name: "generatePlaceGuideFromCategoryFailed",
-                                error_level: "error",
-                                payload: { error: err.message },
-                        });
-                }
-        };
+			const newGuide: PlaceGuide = {
+				id: guide.id,
+				title: guide.title,
+				content: guide.content,
+				category: categoryId,
+				audioUrl,
+			};
+			setPlaceGuides((prev) => [...prev, newGuide]);
+		} catch (err: any) {
+			logFrontendEvent({
+				event_name: "generatePlaceGuideFromCategoryFailed",
+				error_level: "error",
+				payload: { error: err.message },
+			});
+		}
+	};
 
-        const generatePlaceGuidesFromQuestion = async (question: string) => {
-                if (!placeData) return;
-                try {
-                        const { guide, audioUrl } = await callCloudFunction<
-                                GeneratePlaceGuideFromQuestionRequest,
-                                GeneratePlaceGuideFromQuestionResponse
-                        >(
-                                "generatePlaceGuideFromQuestion",
-                                {
-                                        placeId: placeData.id,
-                                        placeName: placeData.name,
-                                        latitude: parseFloat(params.latitude),
-                                        longitude: parseFloat(params.longitude),
-                                        question,
-                                        languageTag: locale,
-                                },
-                                "v1",
-                        );
+	const generatePlaceGuidesFromQuestion = async (question: string) => {
+		if (!placeData) return;
+		try {
+			const { guide, audioUrl } = await callCloudFunction<
+				GeneratePlaceGuideFromQuestionRequest,
+				GeneratePlaceGuideFromQuestionResponse
+			>(
+				"generatePlaceGuideFromQuestion",
+				{
+					placeId: placeData.id,
+					placeName: placeData.name,
+					latitude: parseFloat(params.latitude),
+					longitude: parseFloat(params.longitude),
+					question,
+					languageTag: locale,
+				},
+				"v1",
+			);
 
-                        const newGuide: PlaceGuide = {
-                                id: guide.id,
-                                title: guide.title,
-                                content: guide.content,
-                                category: "custom",
-                                audioUrl,
-                        };
-                        setPlaceGuides((prev) => [...prev, newGuide]);
-                } catch (err: any) {
-                        logFrontendEvent({
-                                event_name: "generatePlaceGuideFromQuestionFailed",
-                                error_level: "error",
-                                payload: { error: err.message },
-                        });
-                }
-        };
+			const newGuide: PlaceGuide = {
+				id: guide.id,
+				title: guide.title,
+				content: guide.content,
+				category: "custom",
+				audioUrl,
+			};
+			setPlaceGuides((prev) => [...prev, newGuide]);
+		} catch (err: any) {
+			logFrontendEvent({
+				event_name: "generatePlaceGuideFromQuestionFailed",
+				error_level: "error",
+				payload: { error: err.message },
+			});
+		}
+	};
 
-        const generateHighlightGuidesFromQuestion = async (id: string, question: string) => {
-                if (!placeData) return;
-                const highlight = highlights.find((h) => h.id === id);
-                if (!highlight) return;
-                const generalGuide = highlight.highlightGuides[0];
+	const generateHighlightGuidesFromQuestion = async (id: string, question: string) => {
+		if (!placeData) return;
+		const highlight = highlights.find((h) => h.id === id);
+		if (!highlight) return;
+		const generalGuide = highlight.highlightGuides[0];
 
-                try {
-                        const { guide, audioUrl } = await callCloudFunction<
-                                GenerateHighlightGuideFromQuestionRequest,
-                                GenerateHighlightGuideFromQuestionResponse
-                        >(
-                                "generateHighlightGuideFromQuestion",
-                                {
-                                        placeId: placeData.id,
-                                        placeName: placeData.name,
-                                        latitude: parseFloat(params.latitude),
-                                        longitude: parseFloat(params.longitude),
-                                        question,
-                                        generalHighlightGuideTitle: generalGuide.title,
-                                        generalHighlightGuideManuscript: generalGuide.content,
-                                        languageTag: locale,
-                                },
-                                "v1",
-                        );
+		try {
+			const { guide, audioUrl } = await callCloudFunction<
+				GenerateHighlightGuideFromQuestionRequest,
+				GenerateHighlightGuideFromQuestionResponse
+			>(
+				"generateHighlightGuideFromQuestion",
+				{
+					placeId: placeData.id,
+					placeName: placeData.name,
+					latitude: parseFloat(params.latitude),
+					longitude: parseFloat(params.longitude),
+					question,
+					generalHighlightGuideTitle: generalGuide.title,
+					generalHighlightGuideManuscript: generalGuide.content,
+					languageTag: locale,
+				},
+				"v1",
+			);
 
-                        setHighlights((prev) =>
-                                prev.map((h) =>
-                                        h.id === id
-                                                ? {
-                                                                ...h,
-                                                                highlightGuides: [
-                                                                        ...h.highlightGuides,
-                                                                        {
-                                                                                id: guide.id,
-                                                                                title: guide.title,
-                                                                                content: guide.content,
-                                                                                category: "custom",
-                                                                                audioUrl,
-                                                                        },
-                                                                ],
-                                                        }
-                                                : h,
-                                ),
-                        );
-                } catch (err: any) {
-                        logFrontendEvent({
-                                event_name: "generateHighlightGuideFromQuestionFailed",
-                                error_level: "error",
-                                payload: { error: err.message },
-                        });
-                }
-        };
+			setHighlights((prev) =>
+				prev.map((h) =>
+					h.id === id
+						? {
+								...h,
+								highlightGuides: [
+									...h.highlightGuides,
+									{
+										id: guide.id,
+										title: guide.title,
+										content: guide.content,
+										category: "custom",
+										audioUrl,
+									},
+								],
+							}
+						: h,
+				),
+			);
+		} catch (err: any) {
+			logFrontendEvent({
+				event_name: "generateHighlightGuideFromQuestionFailed",
+				error_level: "error",
+				payload: { error: err.message },
+			});
+		}
+	};
 
 	const handleCapture = withLoading(async () => {
 		const { status } = await ImagePicker.requestCameraPermissionsAsync();

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -130,13 +130,17 @@ export default function PlaceScreen() {
         const generatePlaceGuidesFromCategory = async (categoryId: string) => {
                 if (!placeData) return;
                 try {
-                        const description = CATEGORY_DESCRIPTION_MAP[categoryId] || categoryId;
+                        const description = CATEGORY_DESCRIPTION_MAP[categoryId];
+                        if (!description) {
+                                throw new Error(`Unknown categoryId: ${categoryId}`);
+                        }
                         const { guide, audioUrl } = await callCloudFunction<
                                 GeneratePlaceGuideFromCategoryRequest,
                                 GeneratePlaceGuideFromCategoryResponse
                         >(
                                 "generatePlaceGuideFromCategory",
                                 {
+                                        categoryId,
                                         placeId: placeData.id,
                                         placeName: placeData.name,
                                         latitude: parseFloat(params.latitude),

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -13,16 +13,36 @@ import i18n from "@/lib/i18n";
 import { useCloudFunction } from "@/hooks/useCloudFunction";
 
 import type {
-	GenerateGeneralPlaceGuideRequest,
-	GenerateGeneralPlaceGuideResponse,
+        GenerateGeneralPlaceGuideRequest,
+        GenerateGeneralPlaceGuideResponse,
 } from "@shared/api/generateGeneralPlaceGuide.schema";
+import type {
+        GeneratePlaceGuideFromCategoryRequest,
+        GeneratePlaceGuideFromCategoryResponse,
+} from "@shared/api/generatePlaceGuideFromCategory.schema";
+import type {
+        GeneratePlaceGuideFromQuestionRequest,
+        GeneratePlaceGuideFromQuestionResponse,
+} from "@shared/api/generatePlaceGuideFromQuestion.schema";
+import type {
+        GenerateHighlightGuideFromQuestionRequest,
+        GenerateHighlightGuideFromQuestionResponse,
+} from "@shared/api/generateHighlightGuideFromQuestion.schema";
 
-import { PlaceGuideCard, PlaceGuide } from "./PlaceGuideCard";
+import { PlaceGuideCard, PlaceGuide, GUIDE_CATEGORIES } from "./PlaceGuideCard";
 import { HighlightCard, Highlight } from "./HighlightCard";
 import { BannerAdView } from "@/components/BannerAdView";
 import { PlaceGuideParams } from "@/types/navigation";
 
 const { width } = Dimensions.get("window");
+
+const CATEGORY_DESCRIPTION_MAP = GUIDE_CATEGORIES.reduce<Record<string, string>>(
+        (acc, c) => {
+                acc[c.id] = c.description;
+                return acc;
+        },
+        {},
+);
 
 type PlaceData = {
 	id: string;
@@ -107,49 +127,131 @@ export default function PlaceScreen() {
 		}
 	};
 
-	const generatePlaceGuidesFromCategory = async (categoryId: string) => {
-		const newGuide: PlaceGuide = {
-			id: `${categoryId}_${Date.now()}`,
-			title: `${categoryId} Guide`,
-			content: `Information about ${categoryId} in ${params.placeName}`,
-			category: categoryId,
-			audioUrl: "",
-		};
-		setPlaceGuides((prev) => [...prev, newGuide]);
-	};
+        const generatePlaceGuidesFromCategory = async (categoryId: string) => {
+                if (!placeData) return;
+                try {
+                        const description = CATEGORY_DESCRIPTION_MAP[categoryId] || categoryId;
+                        const { guide, audioUrl } = await callCloudFunction<
+                                GeneratePlaceGuideFromCategoryRequest,
+                                GeneratePlaceGuideFromCategoryResponse
+                        >(
+                                "generatePlaceGuideFromCategory",
+                                {
+                                        placeId: placeData.id,
+                                        placeName: placeData.name,
+                                        latitude: parseFloat(params.latitude),
+                                        longitude: parseFloat(params.longitude),
+                                        categoryDescription: description,
+                                        languageTag: locale,
+                                },
+                                "v1",
+                        );
 
-	const generatePlaceGuidesFromQuestion = async (question: string) => {
-		const newGuide: PlaceGuide = {
-			id: `custom_${Date.now()}`,
-			title: question,
-			content: `Answer for "${question}" about ${params.placeName}`,
-			category: "custom",
-			audioUrl: "",
-		};
-		setPlaceGuides((prev) => [...prev, newGuide]);
-	};
+                        const newGuide: PlaceGuide = {
+                                id: guide.id,
+                                title: guide.title,
+                                content: guide.content,
+                                category: categoryId,
+                                audioUrl,
+                        };
+                        setPlaceGuides((prev) => [...prev, newGuide]);
+                } catch (err: any) {
+                        logFrontendEvent({
+                                event_name: "generatePlaceGuideFromCategoryFailed",
+                                error_level: "error",
+                                payload: { error: err.message },
+                        });
+                }
+        };
 
-	const generateHighlightGuidesFromQuestion = async (id: string, question: string) => {
-		setHighlights((prev) =>
-			prev.map((h) =>
-				h.id === id
-					? {
-							...h,
-							highlightGuides: [
-								...h.highlightGuides,
-								{
-									id: `${id}_${Date.now()}`,
-									title: question,
-									content: `Answer for "${question}"`,
-									category: "custom",
-									audioUrl: "",
-								},
-							],
-						}
-					: h,
-			),
-		);
-	};
+        const generatePlaceGuidesFromQuestion = async (question: string) => {
+                if (!placeData) return;
+                try {
+                        const { guide, audioUrl } = await callCloudFunction<
+                                GeneratePlaceGuideFromQuestionRequest,
+                                GeneratePlaceGuideFromQuestionResponse
+                        >(
+                                "generatePlaceGuideFromQuestion",
+                                {
+                                        placeId: placeData.id,
+                                        placeName: placeData.name,
+                                        latitude: parseFloat(params.latitude),
+                                        longitude: parseFloat(params.longitude),
+                                        question,
+                                        languageTag: locale,
+                                },
+                                "v1",
+                        );
+
+                        const newGuide: PlaceGuide = {
+                                id: guide.id,
+                                title: guide.title,
+                                content: guide.content,
+                                category: "custom",
+                                audioUrl,
+                        };
+                        setPlaceGuides((prev) => [...prev, newGuide]);
+                } catch (err: any) {
+                        logFrontendEvent({
+                                event_name: "generatePlaceGuideFromQuestionFailed",
+                                error_level: "error",
+                                payload: { error: err.message },
+                        });
+                }
+        };
+
+        const generateHighlightGuidesFromQuestion = async (id: string, question: string) => {
+                if (!placeData) return;
+                const highlight = highlights.find((h) => h.id === id);
+                if (!highlight) return;
+                const generalGuide = highlight.highlightGuides[0];
+
+                try {
+                        const { guide, audioUrl } = await callCloudFunction<
+                                GenerateHighlightGuideFromQuestionRequest,
+                                GenerateHighlightGuideFromQuestionResponse
+                        >(
+                                "generateHighlightGuideFromQuestion",
+                                {
+                                        placeId: placeData.id,
+                                        placeName: placeData.name,
+                                        latitude: parseFloat(params.latitude),
+                                        longitude: parseFloat(params.longitude),
+                                        question,
+                                        generalHighlightGuideTitle: generalGuide.title,
+                                        generalHighlightGuideManuscript: generalGuide.content,
+                                        languageTag: locale,
+                                },
+                                "v1",
+                        );
+
+                        setHighlights((prev) =>
+                                prev.map((h) =>
+                                        h.id === id
+                                                ? {
+                                                                ...h,
+                                                                highlightGuides: [
+                                                                        ...h.highlightGuides,
+                                                                        {
+                                                                                id: guide.id,
+                                                                                title: guide.title,
+                                                                                content: guide.content,
+                                                                                category: "custom",
+                                                                                audioUrl,
+                                                                        },
+                                                                ],
+                                                        }
+                                                : h,
+                                ),
+                        );
+                } catch (err: any) {
+                        logFrontendEvent({
+                                event_name: "generateHighlightGuideFromQuestionFailed",
+                                error_level: "error",
+                                payload: { error: err.message },
+                        });
+                }
+        };
 
 	const handleCapture = withLoading(async () => {
 		const { status } = await ImagePicker.requestCameraPermissionsAsync();

--- a/functions/src/v1/index.ts
+++ b/functions/src/v1/index.ts
@@ -8,3 +8,6 @@ export { pingDb } from "./routes/pingDb";
 export { googlePlacesAutocomplete } from "./routes/googlePlacesAutocomplete";
 export { googlePlacesDetails } from "./routes/googlePlacesDetails";
 export { generateGeneralPlaceGuide } from "./routes/generateGeneralPlaceGuide";
+export { generatePlaceGuideFromCategory } from "./routes/generatePlaceGuideFromCategory";
+export { generatePlaceGuideFromQuestion } from "./routes/generatePlaceGuideFromQuestion";
+export { generateHighlightGuideFromQuestion } from "./routes/generateHighlightGuideFromQuestion";

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -286,14 +286,196 @@ All newline characters in the "manuscript" field must be escaped as \\n.
 		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
 	}
 
-	return {
-		...validatedResponse.data,
-		familyId,
-		variantId,
-		promptText: fullPrompt,
-		generatedText: responseText,
-		promptInput: { placeName, latitude, longitude, languageTag },
-		llmModel,
-		temperature,
-	};
+        return {
+                ...validatedResponse.data,
+                familyId,
+                variantId,
+                promptText: fullPrompt,
+                generatedText: responseText,
+                promptInput: { placeName, latitude, longitude, languageTag },
+                llmModel,
+                temperature,
+        };
+};
+
+export const generatePlaceGuideFromCategoryContent = async (
+        placeName: string,
+        latitude: number,
+        longitude: number,
+        categoryDescription: string,
+        languageTag: string,
+        requestId: string,
+        userId: string,
+): Promise<
+        SpotGuideManuscriptResponse & {
+                familyId: string;
+                variantId: string;
+                promptText: string;
+                generatedText: string;
+                promptInput: Record<string, any>;
+                llmModel: string;
+                temperature: number;
+        }
+> => {
+        const llmModel = "claude-3-haiku-20240307";
+        const temperature = 0.7;
+        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The guide topic is "${categoryDescription}". Output the guide in ${languageTag}.`;
+        const outputHint = `
+Use the following JSON format.
+Make sure the value of "tags" is a string array (not a string).
+All newline characters in the "manuscript" field must be escaped as \\n.
+{
+  title: string;
+  manuscript: string;
+  tags: string[];
+  ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
+}`;
+
+        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+                llmModel,
+                temperature,
+                promptPurpose: "place_guide_from_category_manuscript",
+                variablePromptPart: variablePrompt,
+                outputFormatHint: outputHint,
+                requestId,
+                userId,
+        });
+
+        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+        if (!validatedResponse.success) {
+                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+        }
+
+        return {
+                ...validatedResponse.data,
+                familyId,
+                variantId,
+                promptText: fullPrompt,
+                generatedText: responseText,
+                promptInput: { placeName, latitude, longitude, categoryDescription, languageTag },
+                llmModel,
+                temperature,
+        };
+};
+
+export const generatePlaceGuideFromQuestionContent = async (
+        placeName: string,
+        latitude: number,
+        longitude: number,
+        question: string,
+        languageTag: string,
+        requestId: string,
+        userId: string,
+): Promise<
+        SpotGuideManuscriptResponse & {
+                familyId: string;
+                variantId: string;
+                promptText: string;
+                generatedText: string;
+                promptInput: Record<string, any>;
+                llmModel: string;
+                temperature: number;
+        }
+> => {
+        const llmModel = "claude-3-haiku-20240307";
+        const temperature = 0.7;
+        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The user question is "${question}". Answer in ${languageTag}.`;
+        const outputHint = `
+Use the following JSON format.
+Make sure the value of "tags" is a string array (not a string).
+All newline characters in the "manuscript" field must be escaped as \\n.
+{
+  title: string;
+  manuscript: string;
+  tags: string[];
+  ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
+}`;
+
+        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+                llmModel,
+                temperature,
+                promptPurpose: "place_guide_from_question_manuscript",
+                variablePromptPart: variablePrompt,
+                outputFormatHint: outputHint,
+                requestId,
+                userId,
+        });
+
+        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+        if (!validatedResponse.success) {
+                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+        }
+
+        return {
+                ...validatedResponse.data,
+                familyId,
+                variantId,
+                promptText: fullPrompt,
+                generatedText: responseText,
+                promptInput: { placeName, latitude, longitude, question, languageTag },
+                llmModel,
+                temperature,
+        };
+};
+
+export const generateHighlightGuideFromQuestionContent = async (
+        placeName: string,
+        latitude: number,
+        longitude: number,
+        question: string,
+        generalHighlightGuideTitle: string,
+        generalHighlightGuideManuscript: string,
+        languageTag: string,
+        requestId: string,
+        userId: string,
+): Promise<
+        SpotGuideManuscriptResponse & {
+                familyId: string;
+                variantId: string;
+                promptText: string;
+                generatedText: string;
+                promptInput: Record<string, any>;
+                llmModel: string;
+                temperature: number;
+        }
+> => {
+        const llmModel = "claude-3-haiku-20240307";
+        const temperature = 0.7;
+        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). There is a highlight titled "${generalHighlightGuideTitle}" described as "${generalHighlightGuideManuscript}". The user question is "${question}". Provide an answer in ${languageTag}.`;
+        const outputHint = `
+Use the following JSON format.
+Make sure the value of "tags" is a string array (not a string).
+All newline characters in the "manuscript" field must be escaped as \\n.
+{
+  title: string;
+  manuscript: string;
+  tags: string[];
+  ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
+}`;
+
+        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+                llmModel,
+                temperature,
+                promptPurpose: "highlight_guide_from_question_manuscript",
+                variablePromptPart: variablePrompt,
+                outputFormatHint: outputHint,
+                requestId,
+                userId,
+        });
+
+        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+        if (!validatedResponse.success) {
+                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+        }
+
+        return {
+                ...validatedResponse.data,
+                familyId,
+                variantId,
+                promptText: fullPrompt,
+                generatedText: responseText,
+                promptInput: { placeName, latitude, longitude, question, generalHighlightGuideTitle, generalHighlightGuideManuscript, languageTag },
+                llmModel,
+                temperature,
+        };
 };

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -286,41 +286,41 @@ All newline characters in the "manuscript" field must be escaped as \\n.
 		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
 	}
 
-        return {
-                ...validatedResponse.data,
-                familyId,
-                variantId,
-                promptText: fullPrompt,
-                generatedText: responseText,
-                promptInput: { placeName, latitude, longitude, languageTag },
-                llmModel,
-                temperature,
-        };
+	return {
+		...validatedResponse.data,
+		familyId,
+		variantId,
+		promptText: fullPrompt,
+		generatedText: responseText,
+		promptInput: { placeName, latitude, longitude, languageTag },
+		llmModel,
+		temperature,
+	};
 };
 
 export const generatePlaceGuideFromCategoryContent = async (
-        placeName: string,
-        latitude: number,
-        longitude: number,
-        categoryDescription: string,
-        languageTag: string,
-        requestId: string,
-        userId: string,
+	placeName: string,
+	latitude: number,
+	longitude: number,
+	categoryDescription: string,
+	languageTag: string,
+	requestId: string,
+	userId: string,
 ): Promise<
-        SpotGuideManuscriptResponse & {
-                familyId: string;
-                variantId: string;
-                promptText: string;
-                generatedText: string;
-                promptInput: Record<string, any>;
-                llmModel: string;
-                temperature: number;
-        }
+	SpotGuideManuscriptResponse & {
+		familyId: string;
+		variantId: string;
+		promptText: string;
+		generatedText: string;
+		promptInput: Record<string, any>;
+		llmModel: string;
+		temperature: number;
+	}
 > => {
-        const llmModel = "claude-3-haiku-20240307";
-        const temperature = 0.7;
-        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The guide topic is "${categoryDescription}". Output the guide in ${languageTag}.`;
-        const outputHint = `
+	const llmModel = "claude-3-haiku-20240307";
+	const temperature = 0.7;
+	const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The guide topic is "${categoryDescription}". Output the guide in ${languageTag}.`;
+	const outputHint = `
 Use the following JSON format.
 Make sure the value of "tags" is a string array (not a string).
 All newline characters in the "manuscript" field must be escaped as \\n.
@@ -331,56 +331,56 @@ All newline characters in the "manuscript" field must be escaped as \\n.
   ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
 }`;
 
-        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
-                llmModel,
-                temperature,
-                promptPurpose: "place_guide_from_category_manuscript",
-                variablePromptPart: variablePrompt,
-                outputFormatHint: outputHint,
-                requestId,
-                userId,
-        });
+	const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+		llmModel,
+		temperature,
+		promptPurpose: "place_guide_from_category_manuscript",
+		variablePromptPart: variablePrompt,
+		outputFormatHint: outputHint,
+		requestId,
+		userId,
+	});
 
-        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
-        if (!validatedResponse.success) {
-                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
-        }
+	const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+	if (!validatedResponse.success) {
+		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+	}
 
-        return {
-                ...validatedResponse.data,
-                familyId,
-                variantId,
-                promptText: fullPrompt,
-                generatedText: responseText,
-                promptInput: { placeName, latitude, longitude, categoryDescription, languageTag },
-                llmModel,
-                temperature,
-        };
+	return {
+		...validatedResponse.data,
+		familyId,
+		variantId,
+		promptText: fullPrompt,
+		generatedText: responseText,
+		promptInput: { placeName, latitude, longitude, categoryDescription, languageTag },
+		llmModel,
+		temperature,
+	};
 };
 
 export const generatePlaceGuideFromQuestionContent = async (
-        placeName: string,
-        latitude: number,
-        longitude: number,
-        question: string,
-        languageTag: string,
-        requestId: string,
-        userId: string,
+	placeName: string,
+	latitude: number,
+	longitude: number,
+	question: string,
+	languageTag: string,
+	requestId: string,
+	userId: string,
 ): Promise<
-        SpotGuideManuscriptResponse & {
-                familyId: string;
-                variantId: string;
-                promptText: string;
-                generatedText: string;
-                promptInput: Record<string, any>;
-                llmModel: string;
-                temperature: number;
-        }
+	SpotGuideManuscriptResponse & {
+		familyId: string;
+		variantId: string;
+		promptText: string;
+		generatedText: string;
+		promptInput: Record<string, any>;
+		llmModel: string;
+		temperature: number;
+	}
 > => {
-        const llmModel = "claude-3-haiku-20240307";
-        const temperature = 0.7;
-        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The user question is "${question}". Answer in ${languageTag}.`;
-        const outputHint = `
+	const llmModel = "claude-3-haiku-20240307";
+	const temperature = 0.7;
+	const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The user question is "${question}". Answer in ${languageTag}.`;
+	const outputHint = `
 Use the following JSON format.
 Make sure the value of "tags" is a string array (not a string).
 All newline characters in the "manuscript" field must be escaped as \\n.
@@ -391,58 +391,58 @@ All newline characters in the "manuscript" field must be escaped as \\n.
   ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
 }`;
 
-        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
-                llmModel,
-                temperature,
-                promptPurpose: "place_guide_from_question_manuscript",
-                variablePromptPart: variablePrompt,
-                outputFormatHint: outputHint,
-                requestId,
-                userId,
-        });
+	const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+		llmModel,
+		temperature,
+		promptPurpose: "place_guide_from_question_manuscript",
+		variablePromptPart: variablePrompt,
+		outputFormatHint: outputHint,
+		requestId,
+		userId,
+	});
 
-        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
-        if (!validatedResponse.success) {
-                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
-        }
+	const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+	if (!validatedResponse.success) {
+		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+	}
 
-        return {
-                ...validatedResponse.data,
-                familyId,
-                variantId,
-                promptText: fullPrompt,
-                generatedText: responseText,
-                promptInput: { placeName, latitude, longitude, question, languageTag },
-                llmModel,
-                temperature,
-        };
+	return {
+		...validatedResponse.data,
+		familyId,
+		variantId,
+		promptText: fullPrompt,
+		generatedText: responseText,
+		promptInput: { placeName, latitude, longitude, question, languageTag },
+		llmModel,
+		temperature,
+	};
 };
 
 export const generateHighlightGuideFromQuestionContent = async (
-        placeName: string,
-        latitude: number,
-        longitude: number,
-        question: string,
-        generalHighlightGuideTitle: string,
-        generalHighlightGuideManuscript: string,
-        languageTag: string,
-        requestId: string,
-        userId: string,
+	placeName: string,
+	latitude: number,
+	longitude: number,
+	question: string,
+	generalHighlightGuideTitle: string,
+	generalHighlightGuideManuscript: string,
+	languageTag: string,
+	requestId: string,
+	userId: string,
 ): Promise<
-        SpotGuideManuscriptResponse & {
-                familyId: string;
-                variantId: string;
-                promptText: string;
-                generatedText: string;
-                promptInput: Record<string, any>;
-                llmModel: string;
-                temperature: number;
-        }
+	SpotGuideManuscriptResponse & {
+		familyId: string;
+		variantId: string;
+		promptText: string;
+		generatedText: string;
+		promptInput: Record<string, any>;
+		llmModel: string;
+		temperature: number;
+	}
 > => {
-        const llmModel = "claude-3-haiku-20240307";
-        const temperature = 0.7;
-        const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). There is a highlight titled "${generalHighlightGuideTitle}" described as "${generalHighlightGuideManuscript}". The user question is "${question}". Provide an answer in ${languageTag}.`;
-        const outputHint = `
+	const llmModel = "claude-3-haiku-20240307";
+	const temperature = 0.7;
+	const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). There is a highlight titled "${generalHighlightGuideTitle}" described as "${generalHighlightGuideManuscript}". The user question is "${question}". Provide an answer in ${languageTag}.`;
+	const outputHint = `
 Use the following JSON format.
 Make sure the value of "tags" is a string array (not a string).
 All newline characters in the "manuscript" field must be escaped as \\n.
@@ -453,29 +453,37 @@ All newline characters in the "manuscript" field must be escaped as \\n.
   ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
 }`;
 
-        const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
-                llmModel,
-                temperature,
-                promptPurpose: "highlight_guide_from_question_manuscript",
-                variablePromptPart: variablePrompt,
-                outputFormatHint: outputHint,
-                requestId,
-                userId,
-        });
+	const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+		llmModel,
+		temperature,
+		promptPurpose: "highlight_guide_from_question_manuscript",
+		variablePromptPart: variablePrompt,
+		outputFormatHint: outputHint,
+		requestId,
+		userId,
+	});
 
-        const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
-        if (!validatedResponse.success) {
-                throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
-        }
+	const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+	if (!validatedResponse.success) {
+		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+	}
 
-        return {
-                ...validatedResponse.data,
-                familyId,
-                variantId,
-                promptText: fullPrompt,
-                generatedText: responseText,
-                promptInput: { placeName, latitude, longitude, question, generalHighlightGuideTitle, generalHighlightGuideManuscript, languageTag },
-                llmModel,
-                temperature,
-        };
+	return {
+		...validatedResponse.data,
+		familyId,
+		variantId,
+		promptText: fullPrompt,
+		generatedText: responseText,
+		promptInput: {
+			placeName,
+			latitude,
+			longitude,
+			question,
+			generalHighlightGuideTitle,
+			generalHighlightGuideManuscript,
+			languageTag,
+		},
+		llmModel,
+		temperature,
+	};
 };

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -13,15 +13,15 @@ interface ClaudeMessageResponse {
 		type: "text";
 		text: string;
 		citations:
-			| {
-					type: "char_location";
-					cited_text: string;
-					document_index: number; // x > 0
-					document_title: string | null;
-					start_char_index: number; // x > 0
-					end_char_index: number;
-			  }[]
-			| null;
+		| {
+			type: "char_location";
+			cited_text: string;
+			document_index: number; // x > 0
+			document_title: string | null;
+			start_char_index: number; // x > 0
+			end_char_index: number;
+		}[]
+		| null;
 	}[];
 	stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use";
 	stop_sequence: string | null;
@@ -319,7 +319,9 @@ export const generatePlaceGuideFromCategoryContent = async (
 > => {
 	const llmModel = "claude-3-haiku-20240307";
 	const temperature = 0.7;
-	const variablePrompt = `The place is "${placeName}" located at (${latitude}, ${longitude}). The guide topic is "${categoryDescription}". Output the guide in ${languageTag}.`;
+	const variablePrompt = `The Input is ${JSON.stringify({ placeName, located: `(${latitude}, ${longitude})`, categoryDescription, })} Output the guide in ${languageTag}.
+**HARD RULES**: The content **MUST focus on ${categoryDescription}**
+`;
 	const outputHint = `
 Use the following JSON format.
 Make sure the value of "tags" is a string array (not a string).

--- a/functions/src/v1/routes/generateHighlightGuideFromQuestion.ts
+++ b/functions/src/v1/routes/generateHighlightGuideFromQuestion.ts
@@ -3,8 +3,8 @@ import { logBackendEvent } from "../lib/logger";
 import { withValidatedAuthHandler } from "../lib/handler";
 import { uploadFile } from "../lib/storage";
 import {
-        generateHighlightGuideFromQuestionRequestSchema,
-        GenerateHighlightGuideFromQuestionResponse,
+	generateHighlightGuideFromQuestionRequestSchema,
+	GenerateHighlightGuideFromQuestionResponse,
 } from "../../../../shared/api/generateHighlightGuideFromQuestion.schema";
 import { generateHighlightGuideFromQuestionContent } from "../lib/claude";
 import { synthesizeTextToSpeech } from "../lib/textToSpeech";
@@ -13,88 +13,97 @@ import { getRemoteConfigValue } from "../lib/remoteConfig";
 import { getCurrentVersionFromRequest } from "../lib/backendUtils";
 
 export const generateHighlightGuideFromQuestion = withValidatedAuthHandler(
-        generateHighlightGuideFromQuestionRequestSchema,
-        async function ({ req, res, input, requestId, userId, functionName }) {
-                const { placeId, placeName, latitude, longitude, question, generalHighlightGuideTitle, generalHighlightGuideManuscript, languageTag } = input;
-                const guideId = randomUUID();
+	generateHighlightGuideFromQuestionRequestSchema,
+	async function ({ req, res, input, requestId, userId, functionName }) {
+		const {
+			placeId,
+			placeName,
+			latitude,
+			longitude,
+			question,
+			generalHighlightGuideTitle,
+			generalHighlightGuideManuscript,
+			languageTag,
+		} = input;
+		const guideId = randomUUID();
 
-                const defaultCreatedUserId = await getRemoteConfigValue("v1_highlight_guides_default_created_user_id");
+		const defaultCreatedUserId = await getRemoteConfigValue("v1_highlight_guides_default_created_user_id");
 
-                const {
-                        title,
-                        manuscript,
-                        ssmlGender,
-                        familyId,
-                        variantId,
-                        promptText,
-                        generatedText,
-                        promptInput,
-                        llmModel,
-                        temperature,
-                } = await generateHighlightGuideFromQuestionContent(
-                        placeName,
-                        latitude,
-                        longitude,
-                        question,
-                        generalHighlightGuideTitle,
-                        generalHighlightGuideManuscript,
-                        languageTag,
-                        requestId,
-                        userId,
-                );
+		const {
+			title,
+			manuscript,
+			ssmlGender,
+			familyId,
+			variantId,
+			promptText,
+			generatedText,
+			promptInput,
+			llmModel,
+			temperature,
+		} = await generateHighlightGuideFromQuestionContent(
+			placeName,
+			latitude,
+			longitude,
+			question,
+			generalHighlightGuideTitle,
+			generalHighlightGuideManuscript,
+			languageTag,
+			requestId,
+			userId,
+		);
 
-                const audioBuffer = await synthesizeTextToSpeech({
-                        text: manuscript,
-                        languageTag,
-                        ssmlGender,
-                        requestId,
-                        userId,
-                });
+		const audioBuffer = await synthesizeTextToSpeech({
+			text: manuscript,
+			languageTag,
+			ssmlGender,
+			requestId,
+			userId,
+		});
 
-                const { signedUrl: audioUrl } = await uploadFile({
-                        buffer: audioBuffer,
-                        mimeType: "audio/mpeg",
-                        resourceType: "system-generated",
-                        usageType: "audio-guides",
-                        identifier: placeId,
-                        fileName: guideId,
-                        requestId,
-                        createdVersion: getCurrentVersionFromRequest(req),
-                });
+		const { signedUrl: audioUrl } = await uploadFile({
+			buffer: audioBuffer,
+			mimeType: "audio/mpeg",
+			resourceType: "system-generated",
+			usageType: "audio-guides",
+			identifier: placeId,
+			fileName: guideId,
+			requestId,
+			createdVersion: getCurrentVersionFromRequest(req),
+		});
 
-                // TODO: insert into highlight_guides table
+		// TODO: insert into highlight_guides table
 
-                await prisma.prompt_usages.create({
-                        data: {
-                                id: randomUUID(),
-                                family_id: familyId,
-                                variant_id: variantId,
-                                target_type: "highlight_guides",
-                                target_id: guideId,
-                                generated_text: generatedText,
-                                used_prompt_text: promptText,
-                                input_data: promptInput,
-                                llm_model: llmModel,
-                                temperature,
-                                generated_user: defaultCreatedUserId,
-                                created_at: new Date(),
-                                created_request_id: requestId,
-                        },
-                });
+		await prisma.prompt_usages.create({
+			data: {
+				id: randomUUID(),
+				family_id: familyId,
+				variant_id: variantId,
+				target_type: "highlight_guides",
+				target_id: guideId,
+				generated_text: generatedText,
+				used_prompt_text: promptText,
+				input_data: promptInput,
+				llm_model: llmModel,
+				temperature,
+				generated_user: defaultCreatedUserId,
+				created_at: new Date(),
+				created_request_id: requestId,
+			},
+		});
 
-                logBackendEvent({
-                        event_name: "generateHighlightGuideFromQuestionSuccess",
-                        function_name: functionName,
-                        request_id: requestId,
-                        user_id: userId,
-                        error_level: "info",
-                        payload: { placeName, guideId, languageTag },
-                });
+		logBackendEvent({
+			event_name: "generateHighlightGuideFromQuestionSuccess",
+			function_name: functionName,
+			request_id: requestId,
+			user_id: userId,
+			error_level: "info",
+			payload: { placeName, guideId, languageTag },
+		});
 
-                const response: GenerateHighlightGuideFromQuestionResponse = {
-                        guide: { id: guideId, title, content: manuscript, category: "custom" },
-                        audioUrl,
-                };
-                res.status(200).json(response);
-        },
+		const response: GenerateHighlightGuideFromQuestionResponse = {
+			guide: { id: guideId, title, content: manuscript, category: "custom" },
+			audioUrl,
+		};
+		res.status(200).json(response);
+	},
 );

--- a/functions/src/v1/routes/generateHighlightGuideFromQuestion.ts
+++ b/functions/src/v1/routes/generateHighlightGuideFromQuestion.ts
@@ -1,0 +1,100 @@
+import { prisma } from "../lib/prisma";
+import { logBackendEvent } from "../lib/logger";
+import { withValidatedAuthHandler } from "../lib/handler";
+import { uploadFile } from "../lib/storage";
+import {
+        generateHighlightGuideFromQuestionRequestSchema,
+        GenerateHighlightGuideFromQuestionResponse,
+} from "../../../../shared/api/generateHighlightGuideFromQuestion.schema";
+import { generateHighlightGuideFromQuestionContent } from "../lib/claude";
+import { synthesizeTextToSpeech } from "../lib/textToSpeech";
+import { randomUUID } from "crypto";
+import { getRemoteConfigValue } from "../lib/remoteConfig";
+import { getCurrentVersionFromRequest } from "../lib/backendUtils";
+
+export const generateHighlightGuideFromQuestion = withValidatedAuthHandler(
+        generateHighlightGuideFromQuestionRequestSchema,
+        async function ({ req, res, input, requestId, userId, functionName }) {
+                const { placeId, placeName, latitude, longitude, question, generalHighlightGuideTitle, generalHighlightGuideManuscript, languageTag } = input;
+                const guideId = randomUUID();
+
+                const defaultCreatedUserId = await getRemoteConfigValue("v1_highlight_guides_default_created_user_id");
+
+                const {
+                        title,
+                        manuscript,
+                        ssmlGender,
+                        familyId,
+                        variantId,
+                        promptText,
+                        generatedText,
+                        promptInput,
+                        llmModel,
+                        temperature,
+                } = await generateHighlightGuideFromQuestionContent(
+                        placeName,
+                        latitude,
+                        longitude,
+                        question,
+                        generalHighlightGuideTitle,
+                        generalHighlightGuideManuscript,
+                        languageTag,
+                        requestId,
+                        userId,
+                );
+
+                const audioBuffer = await synthesizeTextToSpeech({
+                        text: manuscript,
+                        languageTag,
+                        ssmlGender,
+                        requestId,
+                        userId,
+                });
+
+                const { signedUrl: audioUrl } = await uploadFile({
+                        buffer: audioBuffer,
+                        mimeType: "audio/mpeg",
+                        resourceType: "system-generated",
+                        usageType: "audio-guides",
+                        identifier: placeId,
+                        fileName: guideId,
+                        requestId,
+                        createdVersion: getCurrentVersionFromRequest(req),
+                });
+
+                // TODO: insert into highlight_guides table
+
+                await prisma.prompt_usages.create({
+                        data: {
+                                id: randomUUID(),
+                                family_id: familyId,
+                                variant_id: variantId,
+                                target_type: "highlight_guides",
+                                target_id: guideId,
+                                generated_text: generatedText,
+                                used_prompt_text: promptText,
+                                input_data: promptInput,
+                                llm_model: llmModel,
+                                temperature,
+                                generated_user: defaultCreatedUserId,
+                                created_at: new Date(),
+                                created_request_id: requestId,
+                        },
+                });
+
+                logBackendEvent({
+                        event_name: "generateHighlightGuideFromQuestionSuccess",
+                        function_name: functionName,
+                        request_id: requestId,
+                        user_id: userId,
+                        error_level: "info",
+                        payload: { placeName, guideId, languageTag },
+                });
+
+                const response: GenerateHighlightGuideFromQuestionResponse = {
+                        guide: { id: guideId, title, content: manuscript, category: "custom" },
+                        audioUrl,
+                };
+                res.status(200).json(response);
+        },
+);

--- a/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
+++ b/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
@@ -15,7 +15,7 @@ import { getCurrentVersionFromRequest } from "../lib/backendUtils";
 export const generatePlaceGuideFromCategory = withValidatedAuthHandler(
         generatePlaceGuideFromCategoryRequestSchema,
         async function ({ req, res, input, requestId, userId, functionName }) {
-                const { placeId, placeName, latitude, longitude, categoryDescription, languageTag } = input;
+                const { categoryId, placeId, placeName, latitude, longitude, categoryDescription, languageTag } = input;
                 const guideId = randomUUID();
 
                 const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
@@ -86,11 +86,11 @@ export const generatePlaceGuideFromCategory = withValidatedAuthHandler(
                         request_id: requestId,
                         user_id: userId,
                         error_level: "info",
-                        payload: { placeName, guideId, categoryDescription, languageTag },
+                        payload: { placeName, guideId, categoryId, categoryDescription, languageTag },
                 });
 
                 const response: GeneratePlaceGuideFromCategoryResponse = {
-                        guide: { id: guideId, title, content: manuscript, category: "category" },
+                        guide: { id: guideId, title, content: manuscript, category: categoryId },
                         audioUrl,
                 };
                 res.status(200).json(response);

--- a/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
+++ b/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
@@ -1,0 +1,98 @@
+import { prisma } from "../lib/prisma";
+import { logBackendEvent } from "../lib/logger";
+import { withValidatedAuthHandler } from "../lib/handler";
+import { uploadFile } from "../lib/storage";
+import {
+        generatePlaceGuideFromCategoryRequestSchema,
+        GeneratePlaceGuideFromCategoryResponse,
+} from "../../../../shared/api/generatePlaceGuideFromCategory.schema";
+import { generatePlaceGuideFromCategoryContent } from "../lib/claude";
+import { synthesizeTextToSpeech } from "../lib/textToSpeech";
+import { randomUUID } from "crypto";
+import { getRemoteConfigValue } from "../lib/remoteConfig";
+import { getCurrentVersionFromRequest } from "../lib/backendUtils";
+
+export const generatePlaceGuideFromCategory = withValidatedAuthHandler(
+        generatePlaceGuideFromCategoryRequestSchema,
+        async function ({ req, res, input, requestId, userId, functionName }) {
+                const { placeId, placeName, latitude, longitude, categoryDescription, languageTag } = input;
+                const guideId = randomUUID();
+
+                const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
+
+                const {
+                        title,
+                        manuscript,
+                        ssmlGender,
+                        familyId,
+                        variantId,
+                        promptText,
+                        generatedText,
+                        promptInput,
+                        llmModel,
+                        temperature,
+                } = await generatePlaceGuideFromCategoryContent(
+                        placeName,
+                        latitude,
+                        longitude,
+                        categoryDescription,
+                        languageTag,
+                        requestId,
+                        userId,
+                );
+
+                const audioBuffer = await synthesizeTextToSpeech({
+                        text: manuscript,
+                        languageTag,
+                        ssmlGender,
+                        requestId,
+                        userId,
+                });
+
+                const { signedUrl: audioUrl } = await uploadFile({
+                        buffer: audioBuffer,
+                        mimeType: "audio/mpeg",
+                        resourceType: "system-generated",
+                        usageType: "audio-guides",
+                        identifier: placeId,
+                        fileName: guideId,
+                        requestId,
+                        createdVersion: getCurrentVersionFromRequest(req),
+                });
+
+                // TODO: insert into place_guides table
+
+                await prisma.prompt_usages.create({
+                        data: {
+                                id: randomUUID(),
+                                family_id: familyId,
+                                variant_id: variantId,
+                                target_type: "place_guides",
+                                target_id: guideId,
+                                generated_text: generatedText,
+                                used_prompt_text: promptText,
+                                input_data: promptInput,
+                                llm_model: llmModel,
+                                temperature,
+                                generated_user: defaultPlaceGuideCreatedUserId,
+                                created_at: new Date(),
+                                created_request_id: requestId,
+                        },
+                });
+
+                logBackendEvent({
+                        event_name: "generatePlaceGuideFromCategorySuccess",
+                        function_name: functionName,
+                        request_id: requestId,
+                        user_id: userId,
+                        error_level: "info",
+                        payload: { placeName, guideId, categoryDescription, languageTag },
+                });
+
+                const response: GeneratePlaceGuideFromCategoryResponse = {
+                        guide: { id: guideId, title, content: manuscript, category: "category" },
+                        audioUrl,
+                };
+                res.status(200).json(response);
+        },
+);

--- a/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
+++ b/functions/src/v1/routes/generatePlaceGuideFromCategory.ts
@@ -3,8 +3,8 @@ import { logBackendEvent } from "../lib/logger";
 import { withValidatedAuthHandler } from "../lib/handler";
 import { uploadFile } from "../lib/storage";
 import {
-        generatePlaceGuideFromCategoryRequestSchema,
-        GeneratePlaceGuideFromCategoryResponse,
+	generatePlaceGuideFromCategoryRequestSchema,
+	GeneratePlaceGuideFromCategoryResponse,
 } from "../../../../shared/api/generatePlaceGuideFromCategory.schema";
 import { generatePlaceGuideFromCategoryContent } from "../lib/claude";
 import { synthesizeTextToSpeech } from "../lib/textToSpeech";
@@ -13,86 +13,86 @@ import { getRemoteConfigValue } from "../lib/remoteConfig";
 import { getCurrentVersionFromRequest } from "../lib/backendUtils";
 
 export const generatePlaceGuideFromCategory = withValidatedAuthHandler(
-        generatePlaceGuideFromCategoryRequestSchema,
-        async function ({ req, res, input, requestId, userId, functionName }) {
-                const { placeId, placeName, latitude, longitude, categoryDescription, languageTag } = input;
-                const guideId = randomUUID();
+	generatePlaceGuideFromCategoryRequestSchema,
+	async function ({ req, res, input, requestId, userId, functionName }) {
+		const { placeId, placeName, latitude, longitude, categoryDescription, languageTag } = input;
+		const guideId = randomUUID();
 
-                const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
+		const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
 
-                const {
-                        title,
-                        manuscript,
-                        ssmlGender,
-                        familyId,
-                        variantId,
-                        promptText,
-                        generatedText,
-                        promptInput,
-                        llmModel,
-                        temperature,
-                } = await generatePlaceGuideFromCategoryContent(
-                        placeName,
-                        latitude,
-                        longitude,
-                        categoryDescription,
-                        languageTag,
-                        requestId,
-                        userId,
-                );
+		const {
+			title,
+			manuscript,
+			ssmlGender,
+			familyId,
+			variantId,
+			promptText,
+			generatedText,
+			promptInput,
+			llmModel,
+			temperature,
+		} = await generatePlaceGuideFromCategoryContent(
+			placeName,
+			latitude,
+			longitude,
+			categoryDescription,
+			languageTag,
+			requestId,
+			userId,
+		);
 
-                const audioBuffer = await synthesizeTextToSpeech({
-                        text: manuscript,
-                        languageTag,
-                        ssmlGender,
-                        requestId,
-                        userId,
-                });
+		const audioBuffer = await synthesizeTextToSpeech({
+			text: manuscript,
+			languageTag,
+			ssmlGender,
+			requestId,
+			userId,
+		});
 
-                const { signedUrl: audioUrl } = await uploadFile({
-                        buffer: audioBuffer,
-                        mimeType: "audio/mpeg",
-                        resourceType: "system-generated",
-                        usageType: "audio-guides",
-                        identifier: placeId,
-                        fileName: guideId,
-                        requestId,
-                        createdVersion: getCurrentVersionFromRequest(req),
-                });
+		const { signedUrl: audioUrl } = await uploadFile({
+			buffer: audioBuffer,
+			mimeType: "audio/mpeg",
+			resourceType: "system-generated",
+			usageType: "audio-guides",
+			identifier: placeId,
+			fileName: guideId,
+			requestId,
+			createdVersion: getCurrentVersionFromRequest(req),
+		});
 
-                // TODO: insert into place_guides table
+		// TODO: insert into place_guides table
 
-                await prisma.prompt_usages.create({
-                        data: {
-                                id: randomUUID(),
-                                family_id: familyId,
-                                variant_id: variantId,
-                                target_type: "place_guides",
-                                target_id: guideId,
-                                generated_text: generatedText,
-                                used_prompt_text: promptText,
-                                input_data: promptInput,
-                                llm_model: llmModel,
-                                temperature,
-                                generated_user: defaultPlaceGuideCreatedUserId,
-                                created_at: new Date(),
-                                created_request_id: requestId,
-                        },
-                });
+		await prisma.prompt_usages.create({
+			data: {
+				id: randomUUID(),
+				family_id: familyId,
+				variant_id: variantId,
+				target_type: "place_guides",
+				target_id: guideId,
+				generated_text: generatedText,
+				used_prompt_text: promptText,
+				input_data: promptInput,
+				llm_model: llmModel,
+				temperature,
+				generated_user: defaultPlaceGuideCreatedUserId,
+				created_at: new Date(),
+				created_request_id: requestId,
+			},
+		});
 
-                logBackendEvent({
-                        event_name: "generatePlaceGuideFromCategorySuccess",
-                        function_name: functionName,
-                        request_id: requestId,
-                        user_id: userId,
-                        error_level: "info",
-                        payload: { placeName, guideId, categoryDescription, languageTag },
-                });
+		logBackendEvent({
+			event_name: "generatePlaceGuideFromCategorySuccess",
+			function_name: functionName,
+			request_id: requestId,
+			user_id: userId,
+			error_level: "info",
+			payload: { placeName, guideId, categoryDescription, languageTag },
+		});
 
-                const response: GeneratePlaceGuideFromCategoryResponse = {
-                        guide: { id: guideId, title, content: manuscript, category: "category" },
-                        audioUrl,
-                };
-                res.status(200).json(response);
-        },
+		const response: GeneratePlaceGuideFromCategoryResponse = {
+			guide: { id: guideId, title, content: manuscript, category: "category" },
+			audioUrl,
+		};
+		res.status(200).json(response);
+	},
 );

--- a/functions/src/v1/routes/generatePlaceGuideFromQuestion.ts
+++ b/functions/src/v1/routes/generatePlaceGuideFromQuestion.ts
@@ -1,0 +1,98 @@
+import { prisma } from "../lib/prisma";
+import { logBackendEvent } from "../lib/logger";
+import { withValidatedAuthHandler } from "../lib/handler";
+import { uploadFile } from "../lib/storage";
+import {
+        generatePlaceGuideFromQuestionRequestSchema,
+        GeneratePlaceGuideFromQuestionResponse,
+} from "../../../../shared/api/generatePlaceGuideFromQuestion.schema";
+import { generatePlaceGuideFromQuestionContent } from "../lib/claude";
+import { synthesizeTextToSpeech } from "../lib/textToSpeech";
+import { randomUUID } from "crypto";
+import { getRemoteConfigValue } from "../lib/remoteConfig";
+import { getCurrentVersionFromRequest } from "../lib/backendUtils";
+
+export const generatePlaceGuideFromQuestion = withValidatedAuthHandler(
+        generatePlaceGuideFromQuestionRequestSchema,
+        async function ({ req, res, input, requestId, userId, functionName }) {
+                const { placeId, placeName, latitude, longitude, question, languageTag } = input;
+                const guideId = randomUUID();
+
+                const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
+
+                const {
+                        title,
+                        manuscript,
+                        ssmlGender,
+                        familyId,
+                        variantId,
+                        promptText,
+                        generatedText,
+                        promptInput,
+                        llmModel,
+                        temperature,
+                } = await generatePlaceGuideFromQuestionContent(
+                        placeName,
+                        latitude,
+                        longitude,
+                        question,
+                        languageTag,
+                        requestId,
+                        userId,
+                );
+
+                const audioBuffer = await synthesizeTextToSpeech({
+                        text: manuscript,
+                        languageTag,
+                        ssmlGender,
+                        requestId,
+                        userId,
+                });
+
+                const { signedUrl: audioUrl } = await uploadFile({
+                        buffer: audioBuffer,
+                        mimeType: "audio/mpeg",
+                        resourceType: "system-generated",
+                        usageType: "audio-guides",
+                        identifier: placeId,
+                        fileName: guideId,
+                        requestId,
+                        createdVersion: getCurrentVersionFromRequest(req),
+                });
+
+                // TODO: insert into place_guides table
+
+                await prisma.prompt_usages.create({
+                        data: {
+                                id: randomUUID(),
+                                family_id: familyId,
+                                variant_id: variantId,
+                                target_type: "place_guides",
+                                target_id: guideId,
+                                generated_text: generatedText,
+                                used_prompt_text: promptText,
+                                input_data: promptInput,
+                                llm_model: llmModel,
+                                temperature,
+                                generated_user: defaultPlaceGuideCreatedUserId,
+                                created_at: new Date(),
+                                created_request_id: requestId,
+                        },
+                });
+
+                logBackendEvent({
+                        event_name: "generatePlaceGuideFromQuestionSuccess",
+                        function_name: functionName,
+                        request_id: requestId,
+                        user_id: userId,
+                        error_level: "info",
+                        payload: { placeName, guideId, languageTag },
+                });
+
+                const response: GeneratePlaceGuideFromQuestionResponse = {
+                        guide: { id: guideId, title, content: manuscript, category: "custom" },
+                        audioUrl,
+                };
+                res.status(200).json(response);
+        },
+);

--- a/functions/src/v1/routes/generatePlaceGuideFromQuestion.ts
+++ b/functions/src/v1/routes/generatePlaceGuideFromQuestion.ts
@@ -3,8 +3,8 @@ import { logBackendEvent } from "../lib/logger";
 import { withValidatedAuthHandler } from "../lib/handler";
 import { uploadFile } from "../lib/storage";
 import {
-        generatePlaceGuideFromQuestionRequestSchema,
-        GeneratePlaceGuideFromQuestionResponse,
+	generatePlaceGuideFromQuestionRequestSchema,
+	GeneratePlaceGuideFromQuestionResponse,
 } from "../../../../shared/api/generatePlaceGuideFromQuestion.schema";
 import { generatePlaceGuideFromQuestionContent } from "../lib/claude";
 import { synthesizeTextToSpeech } from "../lib/textToSpeech";
@@ -13,86 +13,86 @@ import { getRemoteConfigValue } from "../lib/remoteConfig";
 import { getCurrentVersionFromRequest } from "../lib/backendUtils";
 
 export const generatePlaceGuideFromQuestion = withValidatedAuthHandler(
-        generatePlaceGuideFromQuestionRequestSchema,
-        async function ({ req, res, input, requestId, userId, functionName }) {
-                const { placeId, placeName, latitude, longitude, question, languageTag } = input;
-                const guideId = randomUUID();
+	generatePlaceGuideFromQuestionRequestSchema,
+	async function ({ req, res, input, requestId, userId, functionName }) {
+		const { placeId, placeName, latitude, longitude, question, languageTag } = input;
+		const guideId = randomUUID();
 
-                const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
+		const defaultPlaceGuideCreatedUserId = await getRemoteConfigValue("v1_place_guides_default_created_user_id");
 
-                const {
-                        title,
-                        manuscript,
-                        ssmlGender,
-                        familyId,
-                        variantId,
-                        promptText,
-                        generatedText,
-                        promptInput,
-                        llmModel,
-                        temperature,
-                } = await generatePlaceGuideFromQuestionContent(
-                        placeName,
-                        latitude,
-                        longitude,
-                        question,
-                        languageTag,
-                        requestId,
-                        userId,
-                );
+		const {
+			title,
+			manuscript,
+			ssmlGender,
+			familyId,
+			variantId,
+			promptText,
+			generatedText,
+			promptInput,
+			llmModel,
+			temperature,
+		} = await generatePlaceGuideFromQuestionContent(
+			placeName,
+			latitude,
+			longitude,
+			question,
+			languageTag,
+			requestId,
+			userId,
+		);
 
-                const audioBuffer = await synthesizeTextToSpeech({
-                        text: manuscript,
-                        languageTag,
-                        ssmlGender,
-                        requestId,
-                        userId,
-                });
+		const audioBuffer = await synthesizeTextToSpeech({
+			text: manuscript,
+			languageTag,
+			ssmlGender,
+			requestId,
+			userId,
+		});
 
-                const { signedUrl: audioUrl } = await uploadFile({
-                        buffer: audioBuffer,
-                        mimeType: "audio/mpeg",
-                        resourceType: "system-generated",
-                        usageType: "audio-guides",
-                        identifier: placeId,
-                        fileName: guideId,
-                        requestId,
-                        createdVersion: getCurrentVersionFromRequest(req),
-                });
+		const { signedUrl: audioUrl } = await uploadFile({
+			buffer: audioBuffer,
+			mimeType: "audio/mpeg",
+			resourceType: "system-generated",
+			usageType: "audio-guides",
+			identifier: placeId,
+			fileName: guideId,
+			requestId,
+			createdVersion: getCurrentVersionFromRequest(req),
+		});
 
-                // TODO: insert into place_guides table
+		// TODO: insert into place_guides table
 
-                await prisma.prompt_usages.create({
-                        data: {
-                                id: randomUUID(),
-                                family_id: familyId,
-                                variant_id: variantId,
-                                target_type: "place_guides",
-                                target_id: guideId,
-                                generated_text: generatedText,
-                                used_prompt_text: promptText,
-                                input_data: promptInput,
-                                llm_model: llmModel,
-                                temperature,
-                                generated_user: defaultPlaceGuideCreatedUserId,
-                                created_at: new Date(),
-                                created_request_id: requestId,
-                        },
-                });
+		await prisma.prompt_usages.create({
+			data: {
+				id: randomUUID(),
+				family_id: familyId,
+				variant_id: variantId,
+				target_type: "place_guides",
+				target_id: guideId,
+				generated_text: generatedText,
+				used_prompt_text: promptText,
+				input_data: promptInput,
+				llm_model: llmModel,
+				temperature,
+				generated_user: defaultPlaceGuideCreatedUserId,
+				created_at: new Date(),
+				created_request_id: requestId,
+			},
+		});
 
-                logBackendEvent({
-                        event_name: "generatePlaceGuideFromQuestionSuccess",
-                        function_name: functionName,
-                        request_id: requestId,
-                        user_id: userId,
-                        error_level: "info",
-                        payload: { placeName, guideId, languageTag },
-                });
+		logBackendEvent({
+			event_name: "generatePlaceGuideFromQuestionSuccess",
+			function_name: functionName,
+			request_id: requestId,
+			user_id: userId,
+			error_level: "info",
+			payload: { placeName, guideId, languageTag },
+		});
 
-                const response: GeneratePlaceGuideFromQuestionResponse = {
-                        guide: { id: guideId, title, content: manuscript, category: "custom" },
-                        audioUrl,
-                };
-                res.status(200).json(response);
-        },
+		const response: GeneratePlaceGuideFromQuestionResponse = {
+			guide: { id: guideId, title, content: manuscript, category: "custom" },
+			audioUrl,
+		};
+		res.status(200).json(response);
+	},
 );

--- a/shared/api/generateHighlightGuideFromQuestion.schema.ts
+++ b/shared/api/generateHighlightGuideFromQuestion.schema.ts
@@ -1,19 +1,19 @@
 import { z } from "zod";
 
 export const generateHighlightGuideFromQuestionRequestSchema = z.object({
-        placeId: z.string().min(1, "placeId is required"),
-        placeName: z.string().min(1, "placeName is required"),
-        latitude: z.number(),
-        longitude: z.number(),
-        question: z.string().min(1, "question is required"),
-        generalHighlightGuideTitle: z.string().min(1, "generalHighlightGuideTitle is required"),
-        generalHighlightGuideManuscript: z.string().min(1, "generalHighlightGuideManuscript is required"),
-        languageTag: z.string().min(1, "languageTag is required"),
+	placeId: z.string().min(1, "placeId is required"),
+	placeName: z.string().min(1, "placeName is required"),
+	latitude: z.number(),
+	longitude: z.number(),
+	question: z.string().min(1, "question is required"),
+	generalHighlightGuideTitle: z.string().min(1, "generalHighlightGuideTitle is required"),
+	generalHighlightGuideManuscript: z.string().min(1, "generalHighlightGuideManuscript is required"),
+	languageTag: z.string().min(1, "languageTag is required"),
 });
 
 export type GenerateHighlightGuideFromQuestionRequest = z.infer<typeof generateHighlightGuideFromQuestionRequestSchema>;
 
 export type GenerateHighlightGuideFromQuestionResponse = {
-        guide: { id: string; title: string; content: string; category: string };
-        audioUrl: string;
+	guide: { id: string; title: string; content: string; category: string };
+	audioUrl: string;
 };

--- a/shared/api/generateHighlightGuideFromQuestion.schema.ts
+++ b/shared/api/generateHighlightGuideFromQuestion.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const generateHighlightGuideFromQuestionRequestSchema = z.object({
+        placeId: z.string().min(1, "placeId is required"),
+        placeName: z.string().min(1, "placeName is required"),
+        latitude: z.number(),
+        longitude: z.number(),
+        question: z.string().min(1, "question is required"),
+        generalHighlightGuideTitle: z.string().min(1, "generalHighlightGuideTitle is required"),
+        generalHighlightGuideManuscript: z.string().min(1, "generalHighlightGuideManuscript is required"),
+        languageTag: z.string().min(1, "languageTag is required"),
+});
+
+export type GenerateHighlightGuideFromQuestionRequest = z.infer<typeof generateHighlightGuideFromQuestionRequestSchema>;
+
+export type GenerateHighlightGuideFromQuestionResponse = {
+        guide: { id: string; title: string; content: string; category: string };
+        audioUrl: string;
+};

--- a/shared/api/generatePlaceGuideFromCategory.schema.ts
+++ b/shared/api/generatePlaceGuideFromCategory.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const generatePlaceGuideFromCategoryRequestSchema = z.object({
+        placeId: z.string().min(1, "placeId is required"),
+        placeName: z.string().min(1, "placeName is required"),
+        latitude: z.number(),
+        longitude: z.number(),
+        categoryDescription: z.string().min(1, "categoryDescription is required"),
+        languageTag: z.string().min(1, "languageTag is required"),
+});
+
+export type GeneratePlaceGuideFromCategoryRequest = z.infer<typeof generatePlaceGuideFromCategoryRequestSchema>;
+
+export type GeneratePlaceGuideFromCategoryResponse = {
+        guide: { id: string; title: string; content: string; category: string };
+        audioUrl: string;
+};

--- a/shared/api/generatePlaceGuideFromCategory.schema.ts
+++ b/shared/api/generatePlaceGuideFromCategory.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const generatePlaceGuideFromCategoryRequestSchema = z.object({
+        categoryId: z.string().min(1, "categoryId is required"),
         placeId: z.string().min(1, "placeId is required"),
         placeName: z.string().min(1, "placeName is required"),
         latitude: z.number(),

--- a/shared/api/generatePlaceGuideFromCategory.schema.ts
+++ b/shared/api/generatePlaceGuideFromCategory.schema.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 
 export const generatePlaceGuideFromCategoryRequestSchema = z.object({
-        placeId: z.string().min(1, "placeId is required"),
-        placeName: z.string().min(1, "placeName is required"),
-        latitude: z.number(),
-        longitude: z.number(),
-        categoryDescription: z.string().min(1, "categoryDescription is required"),
-        languageTag: z.string().min(1, "languageTag is required"),
+	placeId: z.string().min(1, "placeId is required"),
+	placeName: z.string().min(1, "placeName is required"),
+	latitude: z.number(),
+	longitude: z.number(),
+	categoryDescription: z.string().min(1, "categoryDescription is required"),
+	languageTag: z.string().min(1, "languageTag is required"),
 });
 
 export type GeneratePlaceGuideFromCategoryRequest = z.infer<typeof generatePlaceGuideFromCategoryRequestSchema>;
 
 export type GeneratePlaceGuideFromCategoryResponse = {
-        guide: { id: string; title: string; content: string; category: string };
-        audioUrl: string;
+	guide: { id: string; title: string; content: string; category: string };
+	audioUrl: string;
 };

--- a/shared/api/generatePlaceGuideFromQuestion.schema.ts
+++ b/shared/api/generatePlaceGuideFromQuestion.schema.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 
 export const generatePlaceGuideFromQuestionRequestSchema = z.object({
-        placeId: z.string().min(1, "placeId is required"),
-        placeName: z.string().min(1, "placeName is required"),
-        latitude: z.number(),
-        longitude: z.number(),
-        question: z.string().min(1, "question is required"),
-        languageTag: z.string().min(1, "languageTag is required"),
+	placeId: z.string().min(1, "placeId is required"),
+	placeName: z.string().min(1, "placeName is required"),
+	latitude: z.number(),
+	longitude: z.number(),
+	question: z.string().min(1, "question is required"),
+	languageTag: z.string().min(1, "languageTag is required"),
 });
 
 export type GeneratePlaceGuideFromQuestionRequest = z.infer<typeof generatePlaceGuideFromQuestionRequestSchema>;
 
 export type GeneratePlaceGuideFromQuestionResponse = {
-        guide: { id: string; title: string; content: string; category: string };
-        audioUrl: string;
+	guide: { id: string; title: string; content: string; category: string };
+	audioUrl: string;
 };

--- a/shared/api/generatePlaceGuideFromQuestion.schema.ts
+++ b/shared/api/generatePlaceGuideFromQuestion.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const generatePlaceGuideFromQuestionRequestSchema = z.object({
+        placeId: z.string().min(1, "placeId is required"),
+        placeName: z.string().min(1, "placeName is required"),
+        latitude: z.number(),
+        longitude: z.number(),
+        question: z.string().min(1, "question is required"),
+        languageTag: z.string().min(1, "languageTag is required"),
+});
+
+export type GeneratePlaceGuideFromQuestionRequest = z.infer<typeof generatePlaceGuideFromQuestionRequestSchema>;
+
+export type GeneratePlaceGuideFromQuestionResponse = {
+        guide: { id: string; title: string; content: string; category: string };
+        audioUrl: string;
+};

--- a/shared/remoteConfig/remoteConfig.schema.ts
+++ b/shared/remoteConfig/remoteConfig.schema.ts
@@ -20,8 +20,9 @@ export const remoteConfigSchema = z.object({
 	v1_spot_guides_max_version_major: z.string(),
 	v1_show_like_button: z.string(),
 	v1_show_next_button: z.string(),
-	v1_spot_guides_default_created_user_id: z.string(),
-	v1_place_guides_default_created_user_id: z.string(),
+        v1_spot_guides_default_created_user_id: z.string(),
+        v1_place_guides_default_created_user_id: z.string(),
+        v1_highlight_guides_default_created_user_id: z.string(),
 });
 
 export type RemoteConfigValues = z.infer<typeof remoteConfigSchema>;

--- a/shared/remoteConfig/remoteConfig.schema.ts
+++ b/shared/remoteConfig/remoteConfig.schema.ts
@@ -20,9 +20,9 @@ export const remoteConfigSchema = z.object({
 	v1_spot_guides_max_version_major: z.string(),
 	v1_show_like_button: z.string(),
 	v1_show_next_button: z.string(),
-        v1_spot_guides_default_created_user_id: z.string(),
-        v1_place_guides_default_created_user_id: z.string(),
-        v1_highlight_guides_default_created_user_id: z.string(),
+	v1_spot_guides_default_created_user_id: z.string(),
+	v1_place_guides_default_created_user_id: z.string(),
+	v1_highlight_guides_default_created_user_id: z.string(),
 });
 
 export type RemoteConfigValues = z.infer<typeof remoteConfigSchema>;


### PR DESCRIPTION
## Summary
- add guide category descriptions
- call new Cloud Functions from PlaceScreen
- implement `generatePlaceGuideFromCategory`, `generatePlaceGuideFromQuestion`, and `generateHighlightGuideFromQuestion` routes
- extend Claude helper with category/question functions
- introduce new API schemas and remote config key

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*
- `npx tsc --noEmit -p tsconfig.base.json` *(fails: multiple missing dependency errors)*
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6861ba107224832b81dfd748b21db41a