### PR TITLE
Add camera base64 support and update Claude request

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { View, StyleSheet, Platform, TouchableOpacity, Dimensions } from "react-native";
 import { CameraType, CameraView, FlashMode, useCameraPermissions } from "expo-camera";
-import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
+import { ImageManipulator, SaveFormat, ImageResult } from "expo-image-manipulator";
 import { IconButton, Text, Button } from "react-native-paper";
 import { LinearGradient } from "expo-linear-gradient";
 import {
@@ -33,13 +33,7 @@ const MIN_ZOOM = 0;
 export type CameraScreenProps = {
 	visible: boolean;
 	onClose: () => void;
-	/**
-	 * 撮影後の画像データを通知するハンドラー
-	 *
-	 * - uri: 保存先のローカルファイルパス
-	 * - base64: Base64エンコードされた画像データ
-	 */
-	onCapture: (image: { uri: string; base64: string }) => Promise<void>;
+	onCapture: (image: ImageResult) => Promise<void>;
 };
 
 export const CameraScreen: React.FC<CameraScreenProps> = ({ visible, onClose, onCapture }) => {

--- a/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
@@ -33,7 +33,13 @@ const MIN_ZOOM = 0;
 export type CameraScreenProps = {
 	visible: boolean;
 	onClose: () => void;
-	onCapture: (imageUri: string) => Promise<void>;
+	/**
+	 * 撮影後の画像データを通知するハンドラー
+	 *
+	 * - uri: 保存先のローカルファイルパス
+	 * - base64: Base64エンコードされた画像データ
+	 */
+	onCapture: (image: { uri: string; base64: string }) => Promise<void>;
 };
 
 export const CameraScreen: React.FC<CameraScreenProps> = ({ visible, onClose, onCapture }) => {
@@ -97,9 +103,10 @@ export const CameraScreen: React.FC<CameraScreenProps> = ({ visible, onClose, on
 			const manipulated = await imageRef.saveAsync({
 				format: SaveFormat.JPEG,
 				compress: 0.7,
+				base64: true,
 			});
 
-			await onCapture(manipulated.uri);
+			await onCapture(manipulated);
 
 			logFrontendEvent({
 				event_name: "placeCaptureSuccess",

--- a/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect } from "react";
 import { View, StyleSheet } from "react-native";
 import { Text, IconButton } from "react-native-paper";
 import { Audio } from "expo-av";
-import i18n from "@/lib/i18n";
 
 /**
  * 📚 GuideInteractionSection

--- a/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 import { View, StyleSheet } from "react-native";
 import { Text, IconButton } from "react-native-paper";
 import { Audio } from "expo-av";
+import i18n from "@/lib/i18n";
 
 /**
  * 📚 GuideInteractionSection
@@ -74,7 +75,7 @@ export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = (
 						{guide.title}
 					</Text>
 					<Text style={[styles.content, isFirst && styles.firstContent]} numberOfLines={6}>
-						{guide.content}
+						{guide.content || i18n.t("SpotGuideCard.generating")}
 					</Text>
 				</View>
 				<View style={styles.actionsContainer}>

--- a/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
@@ -75,7 +75,7 @@ export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = (
 						{guide.title}
 					</Text>
 					<Text style={[styles.content, isFirst && styles.firstContent]} numberOfLines={6}>
-						{guide.content || i18n.t("SpotGuideCard.generating")}
+						{guide.content}
 					</Text>
 				</View>
 				<View style={styles.actionsContainer}>

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -265,6 +265,8 @@ export default function PlaceScreen() {
 	 */
 	const handleCameraCapture = useCallback(
 		async (image: { uri: string; base64?: string }) => {
+			const tempHighlightId = `temp_${Date.now()}`;
+			const tempGuideId = `temp_guide_${Date.now()}`;
 			try {
 				logFrontendEvent({
 					event_name: "placeCameraCapture",
@@ -276,8 +278,7 @@ export default function PlaceScreen() {
 					throw new Error("Image base64 data is missing");
 				}
 
-				const tempHighlightId = `temp_${Date.now()}`;
-				const tempGuideId = `temp_guide_${Date.now()}`;
+				// ガイド生成中は「生成中」と表示するための一時的なハイライトを追加
 				setHighlights((prev) => [
 					...prev,
 					{
@@ -287,7 +288,7 @@ export default function PlaceScreen() {
 							{
 								id: tempGuideId,
 								title: "",
-								content: "",
+								content: i18n.t("SpotGuideCard.generating"),
 								category: "general",
 								audioUrl: "",
 							},
@@ -302,6 +303,7 @@ export default function PlaceScreen() {
 					carouselRef.current?.scrollTo({ index: newIndex, animated: true });
 				}, 100);
 
+				// ハイライトを生成するためのAPIを呼び出す
 				const { highlight } = await callCloudFunction<CreateHighlightRequest, CreateHighlightResponse>(
 					"createHighlight",
 					{
@@ -316,6 +318,7 @@ export default function PlaceScreen() {
 					"v1",
 				);
 
+				// 一時的なハイライトを実際のハイライトに置き換える
 				setHighlights((prev) =>
 					prev.map((h) =>
 						h.id === tempHighlightId
@@ -339,6 +342,9 @@ export default function PlaceScreen() {
 				});
 			} catch (error: any) {
 				showSnackbar(i18n.t("PlaceGuide.generateError"));
+				setShowCamera(false);
+				// 生成中の一時的なハイライトを削除
+				setHighlights((prev) => prev.filter((h) => h.id !== tempHighlightId));
 				logFrontendEvent({
 					event_name: "placeCameraCaptureFailed",
 					error_level: "error",

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -33,6 +33,7 @@ import { HighlightCard, Highlight } from "./HighlightCard";
 import { CameraScreen } from "./CameraScreen";
 import { BannerAdView } from "@/components/BannerAdView";
 import { PlaceGuideParams } from "@/types/navigation";
+import { useSnackbar } from "@/contexts/SnackbarProvider";
 
 const { width } = Dimensions.get("window");
 
@@ -54,6 +55,7 @@ export default function PlaceScreen() {
 	const { logFrontendEvent } = useLogger();
 	const { isLoading, withLoading } = useWithLoading();
 	const { callCloudFunction } = useCloudFunction();
+	const { showSnackbar } = useSnackbar();
 
 	const [placeData, setPlaceData] = useState<PlaceData | null>(null);
 	const [placeGuides, setPlaceGuides] = useState<PlaceGuide[]>([]);

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -26,6 +26,7 @@ import type {
 	GenerateHighlightGuideFromQuestionRequest,
 	GenerateHighlightGuideFromQuestionResponse,
 } from "@shared/api/generateHighlightGuideFromQuestion.schema";
+import type { CreateHighlightRequest, CreateHighlightResponse } from "@shared/api/createHighlight.schema";
 
 import { PlaceGuideCard, PlaceGuide, GUIDE_CATEGORIES } from "./PlaceGuideCard";
 import { HighlightCard, Highlight } from "./HighlightCard";
@@ -261,7 +262,7 @@ export default function PlaceScreen() {
 	 * カルーセルを新しいハイライトに移動する
 	 */
 	const handleCameraCapture = useCallback(
-		async (imageUri: string) => {
+		async (image: { uri: string; base64: string }) => {
 			try {
 				logFrontendEvent({
 					event_name: "placeCameraCapture",
@@ -269,28 +270,34 @@ export default function PlaceScreen() {
 					payload: { placeId: params.placeId },
 				});
 
-				// 新しいハイライトを作成
-				const newHighlight: Highlight = {
-					id: `highlight_${Date.now()}`,
-					imageUri,
-					highlightGuides: [
-						{
-							id: `guide_${Date.now()}`,
-							title: "Photo Analysis",
-							content: `This is an analysis of your captured photo at ${params.placeName}. The AI has identified interesting elements and can provide detailed information about what's visible in the image.`,
-							category: "photo_analysis",
-							audioUrl: "",
-						},
-					],
-				};
+				// Cloud Function へハイライト作成リクエスト
+				const { highlight } = await callCloudFunction<CreateHighlightRequest, CreateHighlightResponse>(
+					"createHighlight",
+					{
+						placeId: params.placeId,
+						placeName: params.placeName,
+						latitude: parseFloat(params.latitude),
+						longitude: parseFloat(params.longitude),
+						imageBase64: image.base64,
+						languageTag: locale,
+					},
+					"v1",
+				);
 
 				// ハイライトリストに追加
-				setHighlights((prev) => [...prev, newHighlight]);
+				setHighlights((prev) => [
+					...prev,
+					{
+						id: highlight.id,
+						imageUri: highlight.imageUrl,
+						highlightGuides: highlight.highlightGuides,
+					},
+				]);
 
 				// カメラ画面を閉じる
 				setShowCamera(false);
 
-				// 新しいハイライトにカルーセルを移動（少し遅延を入れて確実に移動）
+				// 新しいハイライトにカルーセルを移動
 				setTimeout(() => {
 					const newIndex = highlights.length + 1; // place + existing highlights + new highlight
 					carouselRef.current?.scrollTo({ index: newIndex, animated: true });
@@ -301,7 +308,7 @@ export default function PlaceScreen() {
 					error_level: "info",
 					payload: {
 						placeId: params.placeId,
-						highlightId: newHighlight.id,
+						highlightId: highlight.id,
 						totalHighlights: highlights.length + 1,
 					},
 				});
@@ -316,7 +323,7 @@ export default function PlaceScreen() {
 				});
 			}
 		},
-		[params.placeId, params.placeName, highlights.length],
+		[params.placeId, params.placeName, highlights.length, locale, callCloudFunction],
 	);
 
 	/**

--- a/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { View, StyleSheet, Dimensions } from "react-native";
+import { View, StyleSheet, Dimensions, Platform } from "react-native";
 import { IconButton, Text } from "react-native-paper";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import Carousel, { ICarouselInstance } from "react-native-reanimated-carousel";
@@ -262,7 +262,7 @@ export default function PlaceScreen() {
 	 * カルーセルを新しいハイライトに移動する
 	 */
 	const handleCameraCapture = useCallback(
-		async (image: { uri: string; base64: string }) => {
+		async (image: { uri: string; base64?: string }) => {
 			try {
 				logFrontendEvent({
 					event_name: "placeCameraCapture",
@@ -270,7 +270,36 @@ export default function PlaceScreen() {
 					payload: { placeId: params.placeId },
 				});
 
-				// Cloud Function へハイライト作成リクエスト
+				if (!image.base64) {
+					throw new Error("Image base64 data is missing");
+				}
+
+				const tempHighlightId = `temp_${Date.now()}`;
+				const tempGuideId = `temp_guide_${Date.now()}`;
+				setHighlights((prev) => [
+					...prev,
+					{
+						id: tempHighlightId,
+						imageUri: image.uri,
+						highlightGuides: [
+							{
+								id: tempGuideId,
+								title: "",
+								content: "",
+								category: "general",
+								audioUrl: "",
+							},
+						],
+					},
+				]);
+
+				setShowCamera(false);
+
+				const newIndex = highlights.length + 1;
+				setTimeout(() => {
+					carouselRef.current?.scrollTo({ index: newIndex, animated: true });
+				}, 100);
+
 				const { highlight } = await callCloudFunction<CreateHighlightRequest, CreateHighlightResponse>(
 					"createHighlight",
 					{
@@ -279,29 +308,23 @@ export default function PlaceScreen() {
 						latitude: parseFloat(params.latitude),
 						longitude: parseFloat(params.longitude),
 						imageBase64: image.base64,
+						mimeType: Platform.OS === "web" ? "image/png" : "image/jpeg",
 						languageTag: locale,
 					},
 					"v1",
 				);
 
-				// ハイライトリストに追加
-				setHighlights((prev) => [
-					...prev,
-					{
-						id: highlight.id,
-						imageUri: highlight.imageUrl,
-						highlightGuides: highlight.highlightGuides,
-					},
-				]);
-
-				// カメラ画面を閉じる
-				setShowCamera(false);
-
-				// 新しいハイライトにカルーセルを移動
-				setTimeout(() => {
-					const newIndex = highlights.length + 1; // place + existing highlights + new highlight
-					carouselRef.current?.scrollTo({ index: newIndex, animated: true });
-				}, 100);
+				setHighlights((prev) =>
+					prev.map((h) =>
+						h.id === tempHighlightId
+							? {
+									id: highlight.id,
+									imageUri: image.uri,
+									highlightGuides: highlight.highlightGuides,
+								}
+							: h,
+					),
+				);
 
 				logFrontendEvent({
 					event_name: "placeCameraCaptureSuccess",
@@ -313,6 +336,7 @@ export default function PlaceScreen() {
 					},
 				});
 			} catch (error: any) {
+				showSnackbar(i18n.t("PlaceGuide.generateError"));
 				logFrontendEvent({
 					event_name: "placeCameraCaptureFailed",
 					error_level: "error",

--- a/functions/src/v1/index.ts
+++ b/functions/src/v1/index.ts
@@ -11,3 +11,4 @@ export { generateGeneralPlaceGuide } from "./routes/generateGeneralPlaceGuide";
 export { generatePlaceGuideFromCategory } from "./routes/generatePlaceGuideFromCategory";
 export { generatePlaceGuideFromQuestion } from "./routes/generatePlaceGuideFromQuestion";
 export { generateHighlightGuideFromQuestion } from "./routes/generateHighlightGuideFromQuestion";
+export { createHighlight } from "./routes/createHighlight";

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -523,6 +523,7 @@ export const generateGeneralHighlightGuideContent = async (
 	latitude: number,
 	longitude: number,
 	imageBase64: string,
+	mimeType: string,
 	languageTag: string,
 	requestId: string,
 	userId: string,
@@ -562,6 +563,7 @@ All newline characters in the "manuscript" field must be escaped as \\n.
 		variablePromptPart: variablePrompt,
 		outputFormatHint: outputHint,
 		imageBase64,
+		mimeType,
 		requestId,
 		userId,
 	});

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -100,31 +100,30 @@ export const callClaudeWithPrompt = async ({
 
 	const fullPrompt = `${systemPrompt}\n\n${userText}`;
 
+	const userContent = imageBase64
+		? [
+				{
+					type: "image",
+					source: {
+						type: "base64",
+						media_type: mimeType,
+						data: imageBase64.replace(/^data:[^,]+,/, ""),
+					},
+				},
+				{ type: "text", text: userText },
+			]
+		: userText;
+
 	const requestPayload = {
 		model: llmModel,
 		max_tokens: 512,
 		temperature,
 		system: systemPrompt,
 		messages: [
-			imageBase64
-				? {
-						role: "user",
-						content: [
-							{
-								type: "image",
-								source: {
-									type: "base64",
-									media_type: mimeType,
-									data: imageBase64.replace(/^data:[^,]+,/, ""),
-								},
-							},
-							{ type: "text", text: userText },
-						],
-					}
-				: {
-						role: "user",
-						content: userText,
-					},
+			{
+				role: "user",
+				content: userContent,
+			},
 		],
 	};
 

--- a/functions/src/v1/lib/claude.ts
+++ b/functions/src/v1/lib/claude.ts
@@ -13,15 +13,15 @@ interface ClaudeMessageResponse {
 		type: "text";
 		text: string;
 		citations:
-		| {
-			type: "char_location";
-			cited_text: string;
-			document_index: number; // x > 0
-			document_title: string | null;
-			start_char_index: number; // x > 0
-			end_char_index: number;
-		}[]
-		| null;
+			| {
+					type: "char_location";
+					cited_text: string;
+					document_index: number; // x > 0
+					document_title: string | null;
+					start_char_index: number; // x > 0
+					end_char_index: number;
+			  }[]
+			| null;
 	}[];
 	stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use";
 	stop_sequence: string | null;
@@ -59,6 +59,8 @@ export const callClaudeWithPrompt = async ({
 	promptPurpose,
 	variablePromptPart,
 	outputFormatHint,
+	imageBase64,
+	mimeType = "image/jpeg",
 	requestId,
 	userId,
 }: {
@@ -67,6 +69,8 @@ export const callClaudeWithPrompt = async ({
 	promptPurpose: string;
 	variablePromptPart: string;
 	outputFormatHint: string;
+	imageBase64?: string;
+	mimeType?: string;
 	requestId: string;
 	userId: string;
 }): Promise<{
@@ -89,26 +93,38 @@ export const callClaudeWithPrompt = async ({
 		.sort((a, b) => b.variant_number - a.variant_number)[0];
 	if (!selectedVariant) throw new Error("No eligible prompt variants found.");
 
-	const basePrompt = selectedVariant.prompt_text;
+	const systemPrompt = `${selectedVariant.prompt_text}\n\n${outputFormatHint}`.trim();
 
-	// 🧠 プロンプト構築
-	const fullPrompt = `
-${basePrompt}
+	// 🧠 ユーザー向けメッセージ
+	const userText = variablePromptPart.trim();
 
-${variablePromptPart}
-
-${outputFormatHint}
-`.trim();
+	const fullPrompt = `${systemPrompt}\n\n${userText}`;
 
 	const requestPayload = {
 		model: llmModel,
 		max_tokens: 512,
 		temperature,
+		system: systemPrompt,
 		messages: [
-			{
-				role: "user",
-				content: fullPrompt,
-			},
+			imageBase64
+				? {
+						role: "user",
+						content: [
+							{
+								type: "image",
+								source: {
+									type: "base64",
+									media_type: mimeType,
+									data: imageBase64.replace(/^data:[^,]+,/, ""),
+								},
+							},
+							{ type: "text", text: userText },
+						],
+					}
+				: {
+						role: "user",
+						content: userText,
+					},
 		],
 	};
 
@@ -322,7 +338,7 @@ export const generatePlaceGuideFromCategoryContent = async (
 > => {
 	const llmModel = "claude-3-haiku-20240307";
 	const temperature = 0.7;
-	const variablePrompt = `The Input is ${JSON.stringify({ placeName, located: `(${latitude}, ${longitude})`, categoryDescription, })} Output the guide in ${languageTag}.
+	const variablePrompt = `The Input is ${JSON.stringify({ placeName, located: `(${latitude}, ${longitude})`, categoryDescription })} Output the guide in ${languageTag}.
 **HARD RULES**: The content **MUST focus on ${categoryDescription}**
 `;
 	const outputHint = `
@@ -498,6 +514,71 @@ All newline characters in the "manuscript" field must be escaped as \\n.
 			generalHighlightGuideManuscript,
 			languageTag,
 		},
+		llmModel,
+		temperature,
+	};
+};
+
+export const generateGeneralHighlightGuideContent = async (
+	placeName: string,
+	latitude: number,
+	longitude: number,
+	imageBase64: string,
+	languageTag: string,
+	requestId: string,
+	userId: string,
+): Promise<
+	SpotGuideManuscriptResponse & {
+		familyId: string;
+		variantId: string;
+		promptText: string;
+		generatedText: string;
+		promptInput: Record<string, any>;
+		llmModel: string;
+		temperature: number;
+	}
+> => {
+	const llmModel = "claude-3-haiku-20240307";
+	const temperature = 0.7;
+	const variablePrompt = JSON.stringify({
+		placeName,
+		located: `(${latitude}, ${longitude})`,
+		languageTag,
+	});
+	const outputHint = `
+Use the following JSON format.
+Make sure the value of "tags" is a string array (not a string).
+All newline characters in the "manuscript" field must be escaped as \\n.
+{
+  title: string;
+  manuscript: string;
+  tags: string[];
+  ssmlGender: 'FEMALE' | 'MALE' | 'NEUTRAL';
+}`;
+
+	const { responseText, parsedJson, fullPrompt, familyId, variantId } = await callClaudeWithPrompt({
+		llmModel,
+		temperature,
+		promptPurpose: "general_highlight_guide_manuscript",
+		variablePromptPart: variablePrompt,
+		outputFormatHint: outputHint,
+		imageBase64,
+		requestId,
+		userId,
+	});
+
+	const validatedResponse = PlaceGuideManuscriptResponseSchema.safeParse(parsedJson);
+	if (!validatedResponse.success) {
+		throw new Error(`Claude API failed: JSON schema validation error - ${JSON.stringify(validatedResponse.error)}`);
+	}
+
+	return {
+		...validatedResponse.data,
+		familyId,
+		variantId,
+		promptText: fullPrompt,
+		generatedText: responseText,
+		promptInput: { placeName, latitude, longitude, languageTag },
 		llmModel,
 		temperature,
 	};

--- a/functions/src/v1/routes/createHighlight.ts
+++ b/functions/src/v1/routes/createHighlight.ts
@@ -12,7 +12,7 @@ import { getCurrentVersionFromRequest } from "../lib/backendUtils";
 export const createHighlight = withValidatedAuthHandler(
 	createHighlightRequestSchema,
 	async function createHighlight({ req, res, input, requestId, userId, functionName }) {
-		const { placeId, placeName, latitude, longitude, imageBase64, languageTag } = input;
+		const { placeId, placeName, latitude, longitude, imageBase64, mimeType, languageTag } = input;
 		const highlightId = randomUUID();
 		const guideId = randomUUID();
 
@@ -21,7 +21,7 @@ export const createHighlight = withValidatedAuthHandler(
 		const imageBuffer = Buffer.from(imageBase64, "base64");
 		const { signedUrl: imageUrl } = await uploadFile({
 			buffer: imageBuffer,
-			mimeType: "image/jpeg",
+			mimeType,
 			resourceType: "user-uploads",
 			usageType: "photos",
 			identifier: userId,
@@ -46,6 +46,7 @@ export const createHighlight = withValidatedAuthHandler(
 			latitude,
 			longitude,
 			imageBase64,
+			mimeType,
 			languageTag,
 			requestId,
 			userId,

--- a/functions/src/v1/routes/createHighlight.ts
+++ b/functions/src/v1/routes/createHighlight.ts
@@ -1,0 +1,113 @@
+import { prisma } from "../lib/prisma";
+import { logBackendEvent } from "../lib/logger";
+import { withValidatedAuthHandler } from "../lib/handler";
+import { uploadFile } from "../lib/storage";
+import { createHighlightRequestSchema, CreateHighlightResponse } from "../../../../shared/api/createHighlight.schema";
+import { generateGeneralHighlightGuideContent } from "../lib/claude";
+import { synthesizeTextToSpeech } from "../lib/textToSpeech";
+import { randomUUID } from "crypto";
+import { getRemoteConfigValue } from "../lib/remoteConfig";
+import { getCurrentVersionFromRequest } from "../lib/backendUtils";
+
+export const createHighlight = withValidatedAuthHandler(
+	createHighlightRequestSchema,
+	async function createHighlight({ req, res, input, requestId, userId, functionName }) {
+		const { placeId, placeName, latitude, longitude, imageBase64, languageTag } = input;
+		const highlightId = randomUUID();
+		const guideId = randomUUID();
+
+		const defaultCreatedUserId = await getRemoteConfigValue("v1_highlight_guides_default_created_user_id");
+
+		const imageBuffer = Buffer.from(imageBase64, "base64");
+		const { signedUrl: imageUrl } = await uploadFile({
+			buffer: imageBuffer,
+			mimeType: "image/jpeg",
+			resourceType: "user-uploads",
+			usageType: "photos",
+			identifier: userId,
+			fileName: highlightId,
+			requestId,
+			createdVersion: getCurrentVersionFromRequest(req),
+		});
+
+		const {
+			title,
+			manuscript,
+			ssmlGender,
+			familyId,
+			variantId,
+			promptText,
+			generatedText,
+			promptInput,
+			llmModel,
+			temperature,
+		} = await generateGeneralHighlightGuideContent(
+			placeName,
+			latitude,
+			longitude,
+			imageBase64,
+			languageTag,
+			requestId,
+			userId,
+		);
+
+		const audioBuffer = await synthesizeTextToSpeech({
+			text: manuscript,
+			languageTag,
+			ssmlGender,
+			requestId,
+			userId,
+		});
+
+		const { signedUrl: audioUrl } = await uploadFile({
+			buffer: audioBuffer,
+			mimeType: "audio/mpeg",
+			resourceType: "system-generated",
+			usageType: "audio-guides",
+			identifier: highlightId,
+			fileName: guideId,
+			requestId,
+			createdVersion: getCurrentVersionFromRequest(req),
+		});
+
+		// TODO: insert into highlights table
+		// TODO: insert into highlight_guides table
+
+		await prisma.prompt_usages.create({
+			data: {
+				id: randomUUID(),
+				family_id: familyId,
+				variant_id: variantId,
+				target_type: "highlight_guides",
+				target_id: guideId,
+				generated_text: generatedText,
+				used_prompt_text: promptText,
+				input_data: promptInput,
+				llm_model: llmModel,
+				temperature,
+				generated_user: defaultCreatedUserId,
+				created_at: new Date(),
+				created_request_id: requestId,
+			},
+		});
+
+		logBackendEvent({
+			event_name: "createHighlightSuccess",
+			function_name: functionName,
+			request_id: requestId,
+			user_id: userId,
+			error_level: "info",
+			payload: { placeId, highlightId },
+		});
+
+		const response: CreateHighlightResponse = {
+			highlight: {
+				id: highlightId,
+				imageUrl,
+				highlightGuides: [{ id: guideId, title, content: manuscript, category: "general", audioUrl }],
+			},
+		};
+
+		res.status(200).json(response);
+	},
+);

--- a/shared/api/createHighlight.schema.ts
+++ b/shared/api/createHighlight.schema.ts
@@ -9,6 +9,7 @@ export const createHighlightRequestSchema = z.object({
 	latitude: z.number(),
 	longitude: z.number(),
 	imageBase64: z.string().min(1, "imageBase64 is required"),
+	mimeType: z.string().min(1, "mimeType is required"),
 	languageTag: z.string().min(1, "languageTag is required"),
 });
 

--- a/shared/api/createHighlight.schema.ts
+++ b/shared/api/createHighlight.schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * 📝 createHighlight のリクエストスキーマ
+ */
+export const createHighlightRequestSchema = z.object({
+	placeId: z.string().min(1, "placeId is required"),
+	placeName: z.string().min(1, "placeName is required"),
+	latitude: z.number(),
+	longitude: z.number(),
+	imageBase64: z.string().min(1, "imageBase64 is required"),
+	languageTag: z.string().min(1, "languageTag is required"),
+});
+
+export type CreateHighlightRequest = z.infer<typeof createHighlightRequestSchema>;
+
+/**
+ * createHighlight のレスポンス型
+ */
+export type CreateHighlightResponse = {
+	highlight: {
+		id: string;
+		imageUrl: string;
+		highlightGuides: {
+			id: string;
+			title: string;
+			content: string;
+			category: string;
+			audioUrl: string;
+		}[];
+	};
+};


### PR DESCRIPTION
## Summary
- adjust CameraScreen to pass base64 image data to parent handler
- update PlaceScreen to send captured image to `createHighlight` API
- extend Claude helper to allow image messages and new guide generation parameters
- modify `createHighlight` route to use updated Claude function

## Testing
- `npx prettier -w app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx app-expo/app/[locale]/PlaceGuide/PlaceScreen.tsx functions/src/v1/lib/claude.ts functions/src/v1/routes/createHighlight.ts`
- `npx tsc --noEmit -p functions/tsconfig.json` *(failed: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68627785aab4832bbe0dab823f031966