### PR TITLE
Fix reaction target type in GuideInteractionSection

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
@@ -11,7 +11,7 @@ import { toggleReaction, insertReaction } from "@/lib/reactions";
  * ユーザーのリアクションをまとめて扱う小さなコンポーネント。
  */
 
-type PlaceGuide = {
+type Guide = {
 	id: string;
 	title: string;
 	content: string;
@@ -20,11 +20,16 @@ type PlaceGuide = {
 };
 
 type GuideInteractionSectionProps = {
-	guide: PlaceGuide;
+	guide: Guide;
 	isFirst?: boolean;
+	targetType: "place_guides" | "highlight_guides";
 };
 
-export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = ({ guide, isFirst = false }) => {
+export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = ({
+	guide,
+	isFirst = false,
+	targetType,
+}) => {
 	const [isLiked, setIsLiked] = useState(false);
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [sound, setSound] = useState<Audio.Sound | null>(null);
@@ -32,76 +37,73 @@ export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = (
 	/**
 	 * 💖 いいねボタンのトグル
 	 */
-        const handleLikePress = async () => {
-                const willLike = !isLiked;
-                setIsLiked(willLike);
-                try {
-                        await toggleReaction({
-                                willReact: willLike,
-                                target_type: "place_guides",
-                                target_id: guide.id,
-                                action_type: "like",
-                        });
-                } catch {
-                        // ignore
-                }
-        };
+	const handleLikePress = async () => {
+		const willLike = !isLiked;
+		setIsLiked(willLike);
+		try {
+			await toggleReaction({
+				willReact: willLike,
+				target_type: targetType,
+				target_id: guide.id,
+				action_type: "like",
+			});
+		} catch {
+			// ignore
+		}
+	};
 
 	/**
 	 * ▶️ 音声再生のトグル
 	 */
-        const handlePlayPress = useCallback(async () => {
-                if (isPlaying) {
-                        setIsPlaying(false);
-                        if (sound) {
-                                try {
-                                        await sound.stopAsync();
-                                        await sound.unloadAsync();
-                                        await insertReaction({
-                                                target_type: "place_guides",
-                                                target_id: guide.id,
-                                                action_type: "pause",
-                                        });
-                                } catch {}
-                                setSound(null);
-                        }
-                        return;
-                }
-                if (!guide.audioUrl) return;
-                setIsPlaying(true);
-                try {
-                        await insertReaction({
-                                target_type: "place_guides",
-                                target_id: guide.id,
-                                action_type: "play",
-                        });
-                        const { sound: newSound } = await Audio.Sound.createAsync(
-                                { uri: guide.audioUrl },
-                                { shouldPlay: true },
-                        );
-                        setSound(newSound);
-                        newSound.setOnPlaybackStatusUpdate(async (status) => {
-                                if (!status.isLoaded) {
-                                        setIsPlaying(false);
-                                        await newSound.unloadAsync();
-                                        return;
-                                }
-                                if (status.didJustFinish) {
-                                        setIsPlaying(false);
-                                        await newSound.unloadAsync();
-                                        try {
-                                                await insertReaction({
-                                                        target_type: "place_guides",
-                                                        target_id: guide.id,
-                                                        action_type: "finish",
-                                                });
-                                        } catch {}
-                                }
-                        });
-                } catch {
-                        setIsPlaying(false);
-                }
-        }, [isPlaying, guide.audioUrl, sound]);
+	const handlePlayPress = useCallback(async () => {
+		if (isPlaying) {
+			setIsPlaying(false);
+			if (sound) {
+				try {
+					await sound.stopAsync();
+					await sound.unloadAsync();
+					await insertReaction({
+						target_type: targetType,
+						target_id: guide.id,
+						action_type: "pause",
+					});
+				} catch {}
+				setSound(null);
+			}
+			return;
+		}
+		if (!guide.audioUrl) return;
+		setIsPlaying(true);
+		try {
+			await insertReaction({
+				target_type: targetType,
+				target_id: guide.id,
+				action_type: "play",
+			});
+			const { sound: newSound } = await Audio.Sound.createAsync({ uri: guide.audioUrl }, { shouldPlay: true });
+			setSound(newSound);
+			newSound.setOnPlaybackStatusUpdate(async (status) => {
+				if (!status.isLoaded) {
+					setIsPlaying(false);
+					await newSound.unloadAsync();
+					return;
+				}
+				if (status.didJustFinish) {
+					setIsPlaying(false);
+					await newSound.unloadAsync();
+					try {
+						await insertReaction({
+							target_type: targetType,
+							target_id: guide.id,
+							action_type: "finish",
+						});
+					} catch {}
+				}
+			});
+		} catch {
+			setIsPlaying(false);
+		}
+	}, [isPlaying, guide.audioUrl, sound]);
 
 	useEffect(() => {
 		return () => {

--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -71,7 +71,7 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
 				showsVerticalScrollIndicator={false}
 				contentContainerStyle={styles.guidesContent}>
 				{highlight.highlightGuides.map((guide, index) => (
-					<GuideInteractionSection key={guide.id} guide={guide} isFirst={index === 0} />
+					<GuideInteractionSection key={guide.id} guide={guide} isFirst={index === 0} targetType="highlight_guides" />
 				))}
 			</ScrollView>
 

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -140,7 +140,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 				showsVerticalScrollIndicator={false}
 				contentContainerStyle={styles.guidesContent}>
 				{guides.map((guide, index) => (
-					<GuideInteractionSection key={guide.id} guide={guide} isFirst={index === 0} />
+					<GuideInteractionSection key={guide.id} guide={guide} isFirst={index === 0} targetType="place_guides" />
 				))}
 			</ScrollView>
 


### PR DESCRIPTION
## Summary
- make `GuideInteractionSection` accept `targetType`
- update PlaceGuideCard and HighlightCard to pass correct value

## Testing
- `npx prettier -w app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx`
- `npx -y tsc -p app-expo/tsconfig.json --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68645a416c30832ba4873e03a4f118fc