### PR TITLE
Add i18n for place screens

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
@@ -261,7 +261,7 @@ export const CameraScreen: React.FC<CameraScreenProps> = ({ visible, onClose, on
 						style={[styles.captureButton, (isLoading || !isCameraReady) && styles.captureButtonDisabled]}
 						testID="place-capture-button">
 						<View style={styles.captureButtonInner}>
-							<Text style={styles.captureButtonText}>なにこれ</Text>
+							<Text style={styles.captureButtonText}>{i18n.t("SpotCapture.captureButton")}</Text>
 						</View>
 					</TouchableOpacity>
 

--- a/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx
@@ -261,7 +261,7 @@ export const CameraScreen: React.FC<CameraScreenProps> = ({ visible, onClose, on
 						style={[styles.captureButton, (isLoading || !isCameraReady) && styles.captureButtonDisabled]}
 						testID="place-capture-button">
 						<View style={styles.captureButtonInner}>
-							<Text style={styles.captureButtonText}>{i18n.t("SpotCapture.captureButton")}</Text>
+							<Text style={styles.captureButtonText}>{i18n.t("PlaceGuide.captureButton")}</Text>
 						</View>
 					</TouchableOpacity>
 

--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -86,7 +86,7 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom.label")}</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
 				</View>
 			</View>
 

--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -86,7 +86,7 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom.label")}</Text>
 				</View>
 			</View>
 

--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -4,6 +4,7 @@ import { IconButton, Text } from "react-native-paper";
 
 import { useWithLoading } from "@/hooks/useWithLoading";
 import { useLogger } from "@/hooks/useLogger";
+import i18n from "@/lib/i18n";
 
 import { GuideInteractionSection } from "./GuideInteractionSection";
 import { CustomQueryModal } from "./CustomQueryModal";
@@ -85,7 +86,7 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>Custom</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
 				</View>
 			</View>
 

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -155,7 +155,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom.label")}</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
 				</View>
 				{availableCategories.slice(0, 4).map((category) => (
 					<View key={category.id} style={styles.categoryButtonWrapper}>
@@ -168,7 +168,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 							disabled={isLoading}
 							testID={`category-button-${category.id}`}
 						/>
-						<Text style={styles.categoryLabel}>{i18n.t(`PlaceGuide.custom.${category.id}`)}</Text>
+						<Text style={styles.categoryLabel}>{i18n.t(`PlaceGuide.category.${category.id}`)}</Text>
 					</View>
 				))}
 			</View>

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -4,6 +4,7 @@ import { IconButton, Text } from "react-native-paper";
 
 import { useLogger } from "@/hooks/useLogger";
 import { useWithLoading } from "@/hooks/useWithLoading";
+import i18n from "@/lib/i18n";
 
 import { GuideInteractionSection } from "./GuideInteractionSection";
 import { CustomQueryModal } from "./CustomQueryModal";
@@ -154,7 +155,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>Custom</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
 				</View>
 				{availableCategories.slice(0, 4).map((category) => (
 					<View key={category.id} style={styles.categoryButtonWrapper}>
@@ -167,7 +168,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 							disabled={isLoading}
 							testID={`category-button-${category.id}`}
 						/>
-						<Text style={styles.categoryLabel}>{category.label}</Text>
+						<Text style={styles.categoryLabel}>{i18n.t(category.id)}</Text>
 					</View>
 				))}
 			</View>

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -155,7 +155,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 						style={styles.customQueryButton}
 						testID="custom-query-button"
 					/>
-					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom")}</Text>
+					<Text style={styles.categoryLabel}>{i18n.t("PlaceGuide.custom.label")}</Text>
 				</View>
 				{availableCategories.slice(0, 4).map((category) => (
 					<View key={category.id} style={styles.categoryButtonWrapper}>
@@ -168,7 +168,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 							disabled={isLoading}
 							testID={`category-button-${category.id}`}
 						/>
-						<Text style={styles.categoryLabel}>{i18n.t(category.id)}</Text>
+						<Text style={styles.categoryLabel}>{i18n.t(`PlaceGuide.custom.${category.id}`)}</Text>
 					</View>
 				))}
 			</View>

--- a/app-expo/app/[locale]/PlaceMapSelect/index.tsx
+++ b/app-expo/app/[locale]/PlaceMapSelect/index.tsx
@@ -272,7 +272,7 @@ export default function MapScreen() {
 			params: {
 				locale,
 				placeId: selectedLocation.placeId,
-				placeName: selectedLocation.name || "Selected Location",
+				placeName: selectedLocation.name || i18n.t("PlaceMapSelect.selectedLocation"),
 				latitude: selectedLocation.latitude.toString(),
 				longitude: selectedLocation.longitude.toString(),
 				imageUrl: selectedLocation.imageUrl,
@@ -375,7 +375,7 @@ export default function MapScreen() {
 						<View style={styles.expandedSearchContainer}>
 							<View style={styles.searchHeader}>
 								<Text variant="titleMedium" style={styles.searchTitle}>
-									Search Places
+									{i18n.t("PlaceMapSelect.searchPlaces")}
 								</Text>
 								<IconButton
 									icon="close"
@@ -417,7 +417,7 @@ export default function MapScreen() {
 						<>
 							{/* Instruction Text */}
 							<Text variant="bodySmall" style={styles.instructionText}>
-								地図をドラッグして地点を選択してください
+								{i18n.t("PlaceMapSelect.dragToSelect")}
 							</Text>
 
 							{/* Location Display Box */}
@@ -430,7 +430,7 @@ export default function MapScreen() {
 									testID="marker-icon"
 								/>
 								<Text variant="bodyMedium" style={styles.locationText} numberOfLines={1}>
-									{selectedLocation?.name || i18n.t("PlaceMapSelect.searchPlaceholder")}
+									{selectedLocation?.name || i18n.t("PlaceMapSelect.selectedLocation")}
 								</Text>
 								<IconButton icon="magnify" size={20} iconColor="#666" style={styles.searchIcon} testID="search-icon" />
 							</View>
@@ -445,7 +445,7 @@ export default function MapScreen() {
 								labelStyle={styles.nanicoreButtonLabel}
 								contentStyle={styles.nanicoreButtonContent}
 								testID="nanicore-button">
-								なにこれ
+								{i18n.t("SpotRecommend.nanicore")}
 							</Button>
 						</>
 					)}

--- a/app-expo/app/[locale]/PlaceMapSelect/index.tsx
+++ b/app-expo/app/[locale]/PlaceMapSelect/index.tsx
@@ -445,7 +445,7 @@ export default function MapScreen() {
 								labelStyle={styles.nanicoreButtonLabel}
 								contentStyle={styles.nanicoreButtonContent}
 								testID="nanicore-button">
-								{i18n.t("SpotRecommend.nanicore")}
+								{i18n.t("PlaceMapSelect.nanicore")}
 							</Button>
 						</>
 					)}

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -36,8 +36,8 @@
 		"cameraPermissionMessage": "Please allow camera access to take photos of this location.",
 		"allowCamera": "Allow Camera",
 		"captureButton": "What's this?",
-		"custom": {
-			"label": "Custom",
+		"custom": "Custom",
+		"category": {
 			"history": "History",
 			"culture": "Culture",
 			"architecture": "Architecture",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -16,7 +16,8 @@
 		"locationError": "Failed to get current location",
 		"dragToSelect": "Drag the map to select a location",
 		"searchPlaces": "Search Places",
-		"selectedLocation": "Selected Location"
+		"selectedLocation": "Selected Location",
+		"nanicore": "What's this?"
 	},
 	"PlaceGuide": {
 		"loading": "Loading place guide...",
@@ -34,7 +35,18 @@
 		"cameraPermissionTitle": "Camera Access",
 		"cameraPermissionMessage": "Please allow camera access to take photos of this location.",
 		"allowCamera": "Allow Camera",
-		"custom": "Custom"
+		"captureButton": "What's this?",
+		"custom": {
+			"label": "Custom",
+			"history": "History",
+			"culture": "Culture",
+			"architecture": "Architecture",
+			"food": "Food",
+			"nature": "Nature",
+			"people": "People",
+			"cost": "Cost",
+			"safety": "Safety"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "What's this?",
@@ -55,13 +67,5 @@
 	},
 	"SpotRecommend": {
 		"nanicore": "What's this?"
-	},
-	"history": "History",
-	"culture": "Culture",
-	"architecture": "Architecture",
-	"food": "Food",
-	"nature": "Nature",
-	"people": "People",
-	"cost": "Cost",
-	"safety": "Safety"
+	}
 }

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -15,7 +15,8 @@
 		"locationPermissionDenied": "Location permission denied",
 		"locationError": "Failed to get current location",
 		"dragToSelect": "Drag the map to select a location",
-		"searchPlaces": "Search Places"
+		"searchPlaces": "Search Places",
+		"selectedLocation": "Selected Location"
 	},
 	"PlaceGuide": {
 		"loading": "Loading place guide...",
@@ -32,7 +33,8 @@
 		"captureError": "Failed to capture photo. Please try again.",
 		"cameraPermissionTitle": "Camera Access",
 		"cameraPermissionMessage": "Please allow camera access to take photos of this location.",
-		"allowCamera": "Allow Camera"
+		"allowCamera": "Allow Camera",
+		"custom": "Custom"
 	},
 	"SpotCapture": {
 		"captureButton": "What's this?",
@@ -53,5 +55,13 @@
 	},
 	"SpotRecommend": {
 		"nanicore": "What's this?"
-	}
+	},
+	"history": "History",
+	"culture": "Culture",
+	"architecture": "Architecture",
+	"food": "Food",
+	"nature": "Nature",
+	"people": "People",
+	"cost": "Cost",
+	"safety": "Safety"
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -15,7 +15,8 @@
 		"locationPermissionDenied": "位置情報の許可が拒否されました",
 		"locationError": "現在地の取得に失敗しました",
 		"dragToSelect": "地図をドラッグして地点を選択してください",
-		"searchPlaces": "場所を検索"
+		"searchPlaces": "場所を検索",
+		"selectedLocation": "選択した場所"
 	},
 	"PlaceGuide": {
 		"loading": "場所ガイドを読み込み中...",
@@ -32,7 +33,8 @@
 		"captureError": "撮影に失敗しました。もう一度お試しください。",
 		"cameraPermissionTitle": "カメラへのアクセス",
 		"cameraPermissionMessage": "この場所の写真を撮影するには、カメラへのアクセスを許可してください。",
-		"allowCamera": "カメラを許可"
+		"allowCamera": "カメラを許可",
+		"custom": "カスタム"
 	},
 	"SpotCapture": {
 		"captureButton": "なにこれ",
@@ -53,5 +55,13 @@
 	},
 	"SpotRecommend": {
 		"nanicore": "なにこれ"
-	}
+	},
+	"history": "歴史",
+	"culture": "文化",
+	"architecture": "建築",
+	"food": "食べ物",
+	"nature": "自然",
+	"people": "人々",
+	"cost": "費用",
+	"safety": "安全"
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -16,7 +16,8 @@
 		"locationError": "現在地の取得に失敗しました",
 		"dragToSelect": "地図をドラッグして地点を選択してください",
 		"searchPlaces": "場所を検索",
-		"selectedLocation": "選択した場所"
+		"selectedLocation": "選択した場所",
+		"nanicore": "なにこれ"
 	},
 	"PlaceGuide": {
 		"loading": "場所ガイドを読み込み中...",
@@ -34,7 +35,18 @@
 		"cameraPermissionTitle": "カメラへのアクセス",
 		"cameraPermissionMessage": "この場所の写真を撮影するには、カメラへのアクセスを許可してください。",
 		"allowCamera": "カメラを許可",
-		"custom": "カスタム"
+		"captureButton": "なにこれ",
+		"custom": {
+			"label": "カスタム",
+			"history": "歴史",
+			"culture": "文化",
+			"architecture": "建築",
+			"food": "食べ物",
+			"nature": "自然",
+			"people": "人々",
+			"cost": "費用",
+			"safety": "安全"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "なにこれ",
@@ -55,13 +67,5 @@
 	},
 	"SpotRecommend": {
 		"nanicore": "なにこれ"
-	},
-	"history": "歴史",
-	"culture": "文化",
-	"architecture": "建築",
-	"food": "食べ物",
-	"nature": "自然",
-	"people": "人々",
-	"cost": "費用",
-	"safety": "安全"
+	}
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -36,8 +36,8 @@
 		"cameraPermissionMessage": "この場所の写真を撮影するには、カメラへのアクセスを許可してください。",
 		"allowCamera": "カメラを許可",
 		"captureButton": "なにこれ",
-		"custom": {
-			"label": "カスタム",
+		"custom": "カスタム",
+		"category": {
 			"history": "歴史",
 			"culture": "文化",
 			"architecture": "建築",


### PR DESCRIPTION
## Summary
- internationalize text in PlaceMapSelect and PlaceGuide
- update translation files with new keys

## Testing
- `npx prettier -w app-expo/app/[locale]/PlaceMapSelect/index.tsx app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx app-expo/app/[locale]/PlaceGuide/CameraScreen.tsx app-expo/locales/en-US.json app-expo/locales/ja-JP.json`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68645ba7ee9c832b8c71f5a6f9359f89