### PR TITLE
Add fallback images for place guides

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useCallback, useState } from "react";
-import { View, StyleSheet, ScrollView, Image, Platform } from "react-native";
+import { View, StyleSheet, ScrollView } from "react-native";
 import { IconButton, Text } from "react-native-paper";
 
 import { useWithLoading } from "@/hooks/useWithLoading";
@@ -9,6 +9,7 @@ import i18n from "@/lib/i18n";
 import { GuideInteractionSection } from "./GuideInteractionSection";
 import { CustomQueryModal } from "./CustomQueryModal";
 import { GuideBaseCard } from "./components/GuideBaseCard";
+import { getFallbackImageUri } from "@/utils/image";
 
 export type HighlightGuide = {
 	id: string;
@@ -69,9 +70,7 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
         * 📸 画像読み込み失敗時にフォールバック画像へ切り替える。
         */
        const handleImageError = useCallback(() => {
-               const placeholderImage = require("@/assets/images/no_image_logo.png");
-               const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
-               setImageSrc(resolvedAsset.uri);
+               setImageSrc(getFallbackImageUri());
                logFrontendEvent({
                        event_name: "highlightImageLoadError",
                        error_level: "error",

--- a/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/HighlightCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useCallback, useState } from "react";
-import { View, StyleSheet, ScrollView } from "react-native";
+import { View, StyleSheet, ScrollView, Image, Platform } from "react-native";
 import { IconButton, Text } from "react-native-paper";
 
 import { useWithLoading } from "@/hooks/useWithLoading";
@@ -39,8 +39,9 @@ export type HighlightCardProps = {
 export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCustomQuestion, onBackPress }) => {
 	const { isLoading, withLoading } = useWithLoading();
 	const { logFrontendEvent } = useLogger();
-	const [showCustomModal, setShowCustomModal] = useState(false);
-	const scrollRef = useRef<ScrollView>(null);
+       const [showCustomModal, setShowCustomModal] = useState(false);
+       const [imageSrc, setImageSrc] = useState(highlight.imageUri);
+       const scrollRef = useRef<ScrollView>(null);
 
 	useEffect(() => {
 		if (highlight.highlightGuides.length > 1) {
@@ -50,22 +51,39 @@ export const HighlightCard: React.FC<HighlightCardProps> = ({ highlight, onCusto
 		}
 	}, [highlight.highlightGuides.length]);
 
-	const handleCustomQuery = useCallback(
-		withLoading(async (query: string) => {
-			if (!query.trim()) return;
-			await onCustomQuestion(highlight.id, query);
-			setShowCustomModal(false);
-			logFrontendEvent({
-				event_name: "highlightCustomQuery",
-				error_level: "info",
-				payload: { highlightId: highlight.id },
-			});
-		}),
-		[highlight.id, onCustomQuestion, logFrontendEvent],
-	);
+       const handleCustomQuery = useCallback(
+               withLoading(async (query: string) => {
+                       if (!query.trim()) return;
+                       await onCustomQuestion(highlight.id, query);
+                       setShowCustomModal(false);
+                       logFrontendEvent({
+                               event_name: "highlightCustomQuery",
+                               error_level: "info",
+                               payload: { highlightId: highlight.id },
+                       });
+               }),
+               [highlight.id, onCustomQuestion, logFrontendEvent],
+       );
 
-	return (
-		<GuideBaseCard imageUri={highlight.imageUri} onBack={onBackPress}>
+       /**
+        * 📸 画像読み込み失敗時にフォールバック画像へ切り替える。
+        */
+       const handleImageError = useCallback(() => {
+               const placeholderImage = require("@/assets/images/no_image_logo.png");
+               const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
+               setImageSrc(resolvedAsset.uri);
+               logFrontendEvent({
+                       event_name: "highlightImageLoadError",
+                       error_level: "error",
+                       payload: {
+                               highlight_id: highlight.id,
+                               failed_url: highlight.imageUri,
+                       },
+               });
+       }, [highlight.id, highlight.imageUri, logFrontendEvent]);
+
+       return (
+               <GuideBaseCard imageUri={imageSrc} onBack={onBackPress} onImageError={handleImageError}>
 			<ScrollView
 				ref={scrollRef}
 				style={styles.guidesScrollView}

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
-import { View, StyleSheet, ScrollView, Image, Platform } from "react-native";
+import { View, StyleSheet, ScrollView } from "react-native";
 import { IconButton, Text } from "react-native-paper";
 
 import { useLogger } from "@/hooks/useLogger";
@@ -9,6 +9,7 @@ import i18n from "@/lib/i18n";
 import { GuideInteractionSection } from "./GuideInteractionSection";
 import { CustomQueryModal } from "./CustomQueryModal";
 import { GuideBaseCard } from "./components/GuideBaseCard";
+import { getFallbackImageUri } from "@/utils/image";
 
 export type PlaceGuide = {
 	id: string;
@@ -138,9 +139,7 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
         * 📸 画像読み込み失敗時にフォールバック画像へ切り替える。
         */
        const handleImageError = useCallback(() => {
-               const placeholderImage = require("@/assets/images/no_image_logo.png");
-               const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
-               setImageSrc(resolvedAsset.uri);
+               setImageSrc(getFallbackImageUri());
                logFrontendEvent({
                        event_name: "placeImageLoadError",
                        error_level: "error",

--- a/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/PlaceGuideCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
-import { View, StyleSheet, ScrollView } from "react-native";
+import { View, StyleSheet, ScrollView, Image, Platform } from "react-native";
 import { IconButton, Text } from "react-native-paper";
 
 import { useLogger } from "@/hooks/useLogger";
@@ -95,9 +95,10 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 	const { logFrontendEvent } = useLogger();
 	const { isLoading, withLoading } = useWithLoading();
 
-	const [availableCategories, setAvailableCategories] = useState(GUIDE_CATEGORIES);
-	const [showCustomModal, setShowCustomModal] = useState(false);
-	const guidesScrollViewRef = useRef<ScrollView>(null);
+       const [availableCategories, setAvailableCategories] = useState(GUIDE_CATEGORIES);
+       const [showCustomModal, setShowCustomModal] = useState(false);
+       const [imageSrc, setImageSrc] = useState(imageUri);
+       const guidesScrollViewRef = useRef<ScrollView>(null);
 
 	useEffect(() => {
 		if (guides.length > 1) {
@@ -124,17 +125,34 @@ export const PlaceGuideCard: React.FC<PlaceGuideCardProps> = ({
 		[availableCategories, onCategorySelect, logFrontendEvent],
 	);
 
-	const handleCustomQuery = useCallback(
-		withLoading(async (query: string) => {
-			if (!query.trim()) return;
-			await onCustomQuestion(query);
-			setShowCustomModal(false);
-		}),
-		[onCustomQuestion],
-	);
+       const handleCustomQuery = useCallback(
+               withLoading(async (query: string) => {
+                       if (!query.trim()) return;
+                       await onCustomQuestion(query);
+                       setShowCustomModal(false);
+               }),
+               [onCustomQuestion],
+       );
 
-	return (
-		<GuideBaseCard imageUri={imageUri} placeName={placeName} onBack={onBackPress}>
+       /**
+        * 📸 画像読み込み失敗時にフォールバック画像へ切り替える。
+        */
+       const handleImageError = useCallback(() => {
+               const placeholderImage = require("@/assets/images/no_image_logo.png");
+               const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
+               setImageSrc(resolvedAsset.uri);
+               logFrontendEvent({
+                       event_name: "placeImageLoadError",
+                       error_level: "error",
+                       payload: {
+                               place_name: placeName,
+                               failed_url: imageUri,
+                       },
+               });
+       }, [imageUri, placeName, logFrontendEvent]);
+
+       return (
+               <GuideBaseCard imageUri={imageSrc} placeName={placeName} onBack={onBackPress} onImageError={handleImageError}>
 			<ScrollView
 				ref={guidesScrollViewRef}
 				style={styles.guidesScrollView}

--- a/app-expo/app/[locale]/SpotGuide/SpotGuideCard.tsx
+++ b/app-expo/app/[locale]/SpotGuide/SpotGuideCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
-import { View, Image, StyleSheet, Platform, ImageBackground } from "react-native";
+import { View, StyleSheet, ImageBackground } from "react-native";
 import { Text } from "react-native-paper";
 import { Audio, InterruptionModeIOS } from "expo-av";
 import { IconButton } from "react-native-paper";
@@ -21,6 +21,7 @@ import type { SupabaseSpotVisits } from "@shared/converters/convert_spot_visits"
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
+import { getFallbackImageUri } from "@/utils/image";
 
 /**
  * 🧭 SpotGuideCard
@@ -235,19 +236,17 @@ const SpotGuideCard = ({
 	/**
 	 * 📸 画像読み込み失敗時にフォールバック画像へ切り替える。
 	 */
-	const handleImageError = useCallback(() => {
-		const placeholderImage = require("@/assets/images/no_image_logo.png");
-		const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
-		setImageSrc(resolvedAsset.uri);
-		logFrontendEvent({
-			event_name: "imageLoadError",
-			error_level: "error",
-			payload: {
-				spot_id: spot.id,
-				failed_url: imageUri,
-			},
-		});
-	}, [imageUri, spot.id]);
+       const handleImageError = useCallback(() => {
+               setImageSrc(getFallbackImageUri());
+               logFrontendEvent({
+                       event_name: "imageLoadError",
+                       error_level: "error",
+                       payload: {
+                               spot_id: spot.id,
+                               failed_url: imageUri,
+                       },
+               });
+       }, [imageUri, spot.id]);
 
 	/**
 	 * 🔄 初期化処理：最初のガイド生成と訪問記録

--- a/app-expo/app/[locale]/SpotGuide/SpotRecommendCard.tsx
+++ b/app-expo/app/[locale]/SpotGuide/SpotRecommendCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { Image, StyleSheet, Platform, ImageBackground } from "react-native";
+import { StyleSheet, ImageBackground } from "react-native";
 import { Button } from "react-native-paper";
 import { useRouter } from "expo-router";
 import { useLogger } from "@/hooks/useLogger";
@@ -7,6 +7,7 @@ import i18n from "@/lib/i18n";
 import { PrismaExtSpots } from "@shared/converters/convert_ext_spots";
 import { serializeSpotGuideParams } from "@/utils/navigation";
 import { useLocale } from "@/hooks/useLocale";
+import { getFallbackImageUri } from "@/utils/image";
 
 /**
  * 📍 SpotRecommendCard
@@ -28,16 +29,14 @@ const SpotRecommendCard = React.memo(function SpotRecommendCard({ spot }: { spot
 	/**
 	 * 📸 画像読み込み失敗時にローカル画像へフォールバック。
 	 */
-	const handleImageError = useCallback(() => {
-		const placeholderImage = require("@/assets/images/no_image_logo.png");
-		const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
-		setImageSrc(resolvedAsset.uri);
-		logFrontendEvent({
-			event_name: "imageLoadError",
-			error_level: "error",
-			payload: { spot_id: spot.id, failed_url: spot.image_url },
-		});
-	}, [spot.id, spot.image_url]);
+        const handleImageError = useCallback(() => {
+                setImageSrc(getFallbackImageUri());
+                logFrontendEvent({
+                        event_name: "imageLoadError",
+                        error_level: "error",
+                        payload: { spot_id: spot.id, failed_url: spot.image_url },
+                });
+        }, [spot.id, spot.image_url]);
 
 	/**
 	 * 🧭 ボタン押下でスポットガイド画面へ遷移する。

--- a/app-expo/utils/image.ts
+++ b/app-expo/utils/image.ts
@@ -1,0 +1,10 @@
+import { Image, Platform } from "react-native";
+
+/**
+ * Get URI of the fallback image used when remote image loading fails.
+ */
+export const getFallbackImageUri = (): string => {
+  const placeholderImage = require("@/assets/images/no_image_logo.png");
+  const resolvedAsset = Platform.OS === "web" ? placeholderImage : Image.resolveAssetSource(placeholderImage);
+  return resolvedAsset.uri;
+};


### PR DESCRIPTION
## Summary
- handle image loading errors in `PlaceGuideCard` and `HighlightCard`

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm typecheck` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68646839eacc832b9e267aaa1f5f0bf2