### PR TITLE
Fix audio playback loop

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/GuideInteractionSection.tsx
@@ -82,24 +82,25 @@ export const GuideInteractionSection: React.FC<GuideInteractionSectionProps> = (
 			});
 			const { sound: newSound } = await Audio.Sound.createAsync({ uri: guide.audioUrl }, { shouldPlay: true });
 			setSound(newSound);
-			newSound.setOnPlaybackStatusUpdate(async (status) => {
-				if (!status.isLoaded) {
-					setIsPlaying(false);
-					await newSound.unloadAsync();
-					return;
-				}
-				if (status.didJustFinish) {
-					setIsPlaying(false);
-					await newSound.unloadAsync();
-					try {
-						await insertReaction({
-							target_type: targetType,
-							target_id: guide.id,
-							action_type: "finish",
-						});
-					} catch {}
-				}
-			});
+                        newSound.setOnPlaybackStatusUpdate(async (status) => {
+                                if (!status.isLoaded) {
+                                        setIsPlaying(false);
+                                        setSound(null);
+                                        return;
+                                }
+                                if (status.didJustFinish) {
+                                        setIsPlaying(false);
+                                        await newSound.unloadAsync();
+                                        setSound(null);
+                                        try {
+                                                await insertReaction({
+                                                        target_type: targetType,
+                                                        target_id: guide.id,
+                                                        action_type: "finish",
+                                                });
+                                        } catch {}
+                                }
+                        });
 		} catch {
 			setIsPlaying(false);
 		}


### PR DESCRIPTION
## Summary
- break loop on playback status updates by clearing ref and not unloading when status isn't loaded

## Testing
- `pnpm --filter app-expo lint` *(fails: Request was cancelled)*
- `pnpm --filter app-expo typecheck` *(fails: Request was cancelled)*
- `pnpm --filter app-expo test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6868e4d384b8832b9365290905312066