### PR TITLE
Fix CustomQueryModal layout on iOS

### DIFF
--- a/app-expo/app/[locale]/PlaceGuide/CustomQueryModal.tsx
+++ b/app-expo/app/[locale]/PlaceGuide/CustomQueryModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { Portal, Modal, Text, TextInput, Button, IconButton } from "react-native-paper";
 import i18n from "@/lib/i18n";
 
@@ -60,79 +60,90 @@ export const CustomQueryModal: React.FC<CustomQueryModalProps> = ({ visible, onD
 		onDismiss();
 	}, [onDismiss]);
 
-	return (
-		<Portal>
-			<Modal
-				visible={visible}
-				onDismiss={handleDismiss}
-				contentContainerStyle={styles.modalContainer}
-				testID="custom-query-modal">
-				<View style={styles.header}>
-					<Text variant="titleLarge" style={styles.title}>
-						{i18n.t("PlaceGuide.askCustomQuestion")}
-					</Text>
-					<IconButton
-						icon="close"
-						size={20}
-						onPress={handleDismiss}
-						style={styles.closeButton}
-						testID="close-modal-button"
-					/>
-				</View>
+        return (
+                <Portal>
+                        <Modal
+                                visible={visible}
+                                onDismiss={handleDismiss}
+                                contentContainerStyle={styles.modalContainer}
+                                testID="custom-query-modal">
+                                <KeyboardAvoidingView
+                                        behavior={Platform.OS === "ios" ? "padding" : undefined}
+                                        style={styles.avoidingView}>
+                                        <ScrollView
+                                                contentContainerStyle={styles.scrollContainer}
+                                                keyboardShouldPersistTaps="handled">
+                                                <View style={styles.header}>
+                                                        <Text variant="titleLarge" style={styles.title}>
+                                                                {i18n.t("PlaceGuide.askCustomQuestion")}
+                                                        </Text>
+                                                        <IconButton
+                                                                icon="close"
+                                                                size={20}
+                                                                onPress={handleDismiss}
+                                                                style={styles.closeButton}
+                                                                testID="close-modal-button"
+                                                        />
+                                                </View>
 
-				<TextInput
-					label={i18n.t("PlaceGuide.customQueryPlaceholder")}
-					value={query}
-					onChangeText={handleChangeText}
-					mode="outlined"
-					multiline
-					numberOfLines={4}
-					style={styles.textInput}
-					disabled={loading}
-					testID="custom-query-input"
-				/>
+                                                <TextInput
+                                                        label={i18n.t("PlaceGuide.customQueryPlaceholder")}
+                                                        value={query}
+                                                        onChangeText={handleChangeText}
+                                                        mode="outlined"
+                                                        multiline
+                                                        numberOfLines={4}
+                                                        style={styles.textInput}
+                                                        disabled={loading}
+                                                        testID="custom-query-input"
+                                                />
 
-				{/* 現在の入力長をユーザーに示す */}
-				<Text style={styles.charCounter}>{`${queryLength} / ${MAX_VISUAL_LENGTH}`}</Text>
+                                                {/* 現在の入力長をユーザーに示す */}
+                                                <Text style={styles.charCounter}>{`${queryLength} / ${MAX_VISUAL_LENGTH}`}</Text>
 
-				<View style={styles.buttonContainer}>
-					<Button
-						mode="outlined"
-						onPress={handleDismiss}
-						style={styles.cancelButton}
-						disabled={loading}
-						testID="cancel-button">
-						{i18n.t("Common.cancel")}
-					</Button>
-					<Button
-						mode="contained"
-						onPress={handleSubmit}
-						loading={loading}
-						disabled={loading || !query.trim()}
-						style={styles.submitButton}
-						buttonColor="#fe3764"
-						testID="submit-query-button">
-						{i18n.t("PlaceGuide.generateGuides")}
-					</Button>
-				</View>
-			</Modal>
-		</Portal>
-	);
+                                                <View style={styles.buttonContainer}>
+                                                        <Button
+                                                                mode="outlined"
+                                                                onPress={handleDismiss}
+                                                                style={styles.cancelButton}
+                                                                disabled={loading}
+                                                                testID="cancel-button">
+                                                                {i18n.t("Common.cancel")}
+                                                        </Button>
+                                                        <Button
+                                                                mode="contained"
+                                                                onPress={handleSubmit}
+                                                                loading={loading}
+                                                                disabled={loading || !query.trim()}
+                                                                style={styles.submitButton}
+                                                                buttonColor="#fe3764"
+                                                                testID="submit-query-button">
+                                                                {i18n.t("PlaceGuide.generateGuides")}
+                                                        </Button>
+                                                </View>
+                                        </ScrollView>
+                                </KeyboardAvoidingView>
+                        </Modal>
+                </Portal>
+        );
 };
 
 const styles = StyleSheet.create({
-	modalContainer: {
-		backgroundColor: "white",
-		margin: 20,
-		borderRadius: 20,
-		padding: 24,
-		maxHeight: "80%",
-		elevation: 8,
-		shadowColor: "#000",
-		shadowOpacity: 0.15,
-		shadowRadius: 12,
-		shadowOffset: { width: 0, height: 4 },
-	},
+        modalContainer: {
+                backgroundColor: "white",
+                margin: 20,
+                borderRadius: 20,
+                padding: 24,
+                maxHeight: "80%",
+                width: "90%",
+                alignSelf: "center",
+                maxWidth: 480,
+                elevation: 8,
+                shadowColor: "#000",
+                shadowOpacity: 0.15,
+                shadowRadius: 12,
+                shadowOffset: { width: 0, height: 4 },
+        },
 	header: {
 		flexDirection: "row",
 		alignItems: "center",
@@ -160,17 +171,24 @@ const styles = StyleSheet.create({
 		color: "#777",
 		fontSize: 12,
 	},
-	buttonContainer: {
-		flexDirection: "row",
-		gap: 12,
-	},
-	cancelButton: {
-		flex: 1,
-		borderColor: "#e0e0e0",
-		borderRadius: 12,
-	},
-	submitButton: {
-		flex: 1,
-		borderRadius: 12,
-	},
+        buttonContainer: {
+                flexDirection: "row",
+                gap: 12,
+        },
+        cancelButton: {
+                flex: 1,
+                borderColor: "#e0e0e0",
+                borderRadius: 12,
+        },
+        submitButton: {
+                flex: 1,
+                borderRadius: 12,
+        },
+        avoidingView: {
+                flexGrow: 1,
+        },
+        scrollContainer: {
+                flexGrow: 1,
+        },
 });
+


### PR DESCRIPTION
## Summary
- use `KeyboardAvoidingView` and `ScrollView` for proper modal resizing
- center modal container and cap width

## Testing
- `pnpm lint` *(fails: can't fetch from registry)*
- `pnpm typecheck` *(fails: can't fetch from registry)*

------
https://chatgpt.com/codex/tasks/task_e_686bf1cdb978832ba4887cc58eda33e2