### PR TITLE
Add full translations for all locales

### DIFF
--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "إلغاء",
+		"ok": "موافق",
 		"goStore": "افتح متجر التطبيقات"
 	},
 	"Error": {
 		"maintenanceMessage": "نحن حالياً نقوم بأعمال صيانة.",
-		"unsupportedVersion": "لا يمكن استخدام هذا الإصدار القديم."
+		"unsupportedVersion": "هذا الإصدار لم يعد مدعومًا."
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "ابحث عن مكان...",
+		"noResultsFound": "لم يتم العثور على نتائج لبحثك",
+		"searchError": "فشل البحث. الرجاء المحاولة مرة أخرى.",
+		"locationPermissionDenied": "تم رفض الوصول إلى الموقع. الرجاء تمكينه من الإعدادات.",
+		"locationError": "تعذر تحديد موقعك. الرجاء المحاولة مرة أخرى.",
+		"dragToSelect": "اسحب الخريطة لتحديد موقع",
+		"searchPlaces": "ابحث عن أماكن",
+		"selectedLocation": "الموقع المختار",
+		"nanicore": "ما هذا؟"
+	},
+	"PlaceGuide": {
+		"loading": "جارٍ تحميل دليل المكان...",
+		"takePhoto": "التقاط صورة",
+		"askQuestion": "اسأل عن هذا المكان",
+		"askCustomQuestion": "اطرح سؤالاً مخصصًا",
+		"customQueryPlaceholder": "ماذا تريد أن تعرف عن هذا المكان؟",
+		"generateGuides": "إنشاء الدليل",
+		"loadError": "عذرًا، لم نتمكن من تحميل الأدلة. الرجاء المحاولة مرة أخرى.",
+		"generateError": "عذرًا، لم نتمكن من إنشاء الدليل. الرجاء المحاولة مرة أخرى.",
+		"reactionError": "فشل تحديث حالة الإعجاب. الرجاء المحاولة مرة أخرى.",
+		"audioError": "فشل تشغيل الصوت. الرجاء المحاولة مرة أخرى.",
+		"photoAdded": "تمت إضافة الصورة! استكشف الصورة الجديدة.",
+		"guidesGenerated": "تم إنشاء الدليل بنجاح!",
+		"cameraNotReady": "الكاميرا غير جاهزة",
+		"captureError": "فشل التقاط الصورة. الرجاء المحاولة مرة أخرى.",
+		"cameraPermissionTitle": "الوصول إلى الكاميرا",
+		"cameraPermissionMessage": "يرجى السماح بالوصول إلى الكاميرا لالتقاط صور لهذا الموقع.",
+		"allowCamera": "السماح بالكاميرا",
+		"captureButton": "ما هذا؟",
+		"custom": "مخصص",
+		"category": {
+			"must_do": "يجب القيام به",
+			"history": "التاريخ",
+			"culture": "الثقافة",
+			"architecture": "العمارة",
+			"food": "الطعام",
+			"nature": "الطبيعة",
+			"people": "الأشخاص",
+			"cost": "التكلفة",
+			"safety": "السلامة"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "ما هذا؟",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "Cancelar",
+		"ok": "Aceptar",
 		"goStore": "Abrir App Store"
 	},
 	"Error": {
 		"maintenanceMessage": "Actualmente estamos en mantenimiento.",
 		"unsupportedVersion": "Esta versión ya no es compatible."
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "Buscar un lugar...",
+		"noResultsFound": "No se encontraron resultados para tu búsqueda",
+		"searchError": "La búsqueda falló. Por favor, inténtalo de nuevo.",
+		"locationPermissionDenied": "Acceso a la ubicación denegado. Por favor, actívalo en la configuración.",
+		"locationError": "No se pudo determinar tu ubicación. Por favor, inténtalo de nuevo.",
+		"dragToSelect": "Arrastra el mapa para seleccionar una ubicación",
+		"searchPlaces": "Buscar lugares",
+		"selectedLocation": "Ubicación seleccionada",
+		"nanicore": "¿Qué es esto?"
+	},
+	"PlaceGuide": {
+		"loading": "Cargando guía del lugar...",
+		"takePhoto": "Tomar foto",
+		"askQuestion": "Preguntar sobre este lugar",
+		"askCustomQuestion": "Hacer una pregunta personalizada",
+		"customQueryPlaceholder": "¿Qué te gustaría saber de este lugar?",
+		"generateGuides": "Generar guía",
+		"loadError": "Lo sentimos, no pudimos cargar las guías. Por favor, inténtalo de nuevo.",
+		"generateError": "Lo sentimos, no pudimos generar la guía. Por favor, inténtalo de nuevo.",
+		"reactionError": "No se pudo actualizar el estado de Me gusta. Por favor, inténtalo de nuevo.",
+		"audioError": "Error al reproducir el audio. Por favor, inténtalo de nuevo.",
+		"photoAdded": "¡Foto agregada! Explora la nueva imagen.",
+		"guidesGenerated": "¡Guía generada correctamente!",
+		"cameraNotReady": "La cámara no está lista",
+		"captureError": "No se pudo capturar la foto. Por favor, inténtalo de nuevo.",
+		"cameraPermissionTitle": "Acceso a la cámara",
+		"cameraPermissionMessage": "Permite el acceso a la cámara para tomar fotos de este lugar.",
+		"allowCamera": "Permitir cámara",
+		"captureButton": "¿Qué es esto?",
+		"custom": "Personalizado",
+		"category": {
+			"must_do": "Imprescindible",
+			"history": "Historia",
+			"culture": "Cultura",
+			"architecture": "Arquitectura",
+			"food": "Comida",
+			"nature": "Naturaleza",
+			"people": "Personas",
+			"cost": "Costo",
+			"safety": "Seguridad"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "¿Qué es esto?",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "Annuler",
+		"ok": "OK",
 		"goStore": "Ouvrir l’App Store"
 	},
 	"Error": {
 		"maintenanceMessage": "Nous sommes actuellement en maintenance.",
 		"unsupportedVersion": "Cette version n'est plus prise en charge."
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "Rechercher un lieu...",
+		"noResultsFound": "Aucun résultat trouvé pour votre recherche",
+		"searchError": "La recherche a échoué. Veuillez réessayer.",
+		"locationPermissionDenied": "Accès à la localisation refusé. Veuillez l’activer dans les paramètres.",
+		"locationError": "Impossible de déterminer votre position. Veuillez réessayer.",
+		"dragToSelect": "Faites glisser la carte pour sélectionner un lieu",
+		"searchPlaces": "Rechercher des lieux",
+		"selectedLocation": "Lieu sélectionné",
+		"nanicore": "C'est quoi ?"
+	},
+	"PlaceGuide": {
+		"loading": "Chargement du guide du lieu...",
+		"takePhoto": "Prendre une photo",
+		"askQuestion": "Poser une question sur ce lieu",
+		"askCustomQuestion": "Poser une question personnalisée",
+		"customQueryPlaceholder": "Que souhaitez-vous savoir sur ce lieu ?",
+		"generateGuides": "Générer le guide",
+		"loadError": "Désolé, nous n'avons pas pu charger les guides. Veuillez réessayer.",
+		"generateError": "Désolé, nous n'avons pas pu générer le guide. Veuillez réessayer.",
+		"reactionError": "Échec de la mise à jour de l'appréciation. Veuillez réessayer.",
+		"audioError": "La lecture audio a échoué. Veuillez réessayer.",
+		"photoAdded": "Photo ajoutée ! Découvrez la nouvelle image.",
+		"guidesGenerated": "Guide généré avec succès !",
+		"cameraNotReady": "La caméra n'est pas prête",
+		"captureError": "Échec de la prise de photo. Veuillez réessayer.",
+		"cameraPermissionTitle": "Accès à la caméra",
+		"cameraPermissionMessage": "Veuillez autoriser l'accès à la caméra pour prendre des photos de ce lieu.",
+		"allowCamera": "Autoriser la caméra",
+		"captureButton": "C'est quoi ?",
+		"custom": "Personnalisé",
+		"category": {
+			"must_do": "À faire",
+			"history": "Histoire",
+			"culture": "Culture",
+			"architecture": "Architecture",
+			"food": "Gastronomie",
+			"nature": "Nature",
+			"people": "Personnes",
+			"cost": "Coût",
+			"safety": "Sécurité"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "C'est quoi ?",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "रद्द करें",
+		"ok": "ओके",
 		"goStore": "ऐप स्टोर खोलें"
 	},
 	"Error": {
 		"maintenanceMessage": "हम वर्तमान में रखरखाव कर रहे हैं।",
 		"unsupportedVersion": "यह संस्करण अब समर्थित नहीं है।"
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "स्थान खोजें...",
+		"noResultsFound": "आपकी खोज के लिए कोई परिणाम नहीं मिला",
+		"searchError": "खोज विफल हुई। कृपया पुनः प्रयास करें।",
+		"locationPermissionDenied": "स्थान की अनुमति अस्वीकृत। कृपया सेटिंग्स में सक्षम करें।",
+		"locationError": "आपका स्थान निर्धारित नहीं हो पाया। कृपया फिर से प्रयास करें।",
+		"dragToSelect": "स्थान चुनने के लिए मानचित्र खींचें",
+		"searchPlaces": "स्थानों की खोज करें",
+		"selectedLocation": "चयनित स्थान",
+		"nanicore": "यह क्या है"
+	},
+	"PlaceGuide": {
+		"loading": "स्थान गाइड लोड हो रहा है...",
+		"takePhoto": "फोटो लें",
+		"askQuestion": "इस स्थान के बारे में पूछें",
+		"askCustomQuestion": "एक कस्टम प्रश्न पूछें",
+		"customQueryPlaceholder": "आप इस स्थान के बारे में क्या जानना चाहते हैं?",
+		"generateGuides": "गाइड जनरेट करें",
+		"loadError": "क्षमा करें, हम गाइड लोड नहीं कर सके। कृपया पुनः प्रयास करें।",
+		"generateError": "क्षमा करें, हम गाइड जनरेट नहीं कर सके। कृपया पुनः प्रयास करें।",
+		"reactionError": "लाइक स्थिति अपडेट नहीं हो सकी। कृपया पुनः प्रयास करें।",
+		"audioError": "ऑडियो चलाने में विफल। कृपया पुनः प्रयास करें।",
+		"photoAdded": "फोटो जोड़ा गया! नई छवि देखें।",
+		"guidesGenerated": "गाइड सफलतापूर्वक जनरेट हुआ!",
+		"cameraNotReady": "कैमरा तैयार नहीं है",
+		"captureError": "फोटो कैप्चर करने में विफल। कृपया पुनः प्रयास करें।",
+		"cameraPermissionTitle": "कैमरा एक्सेस",
+		"cameraPermissionMessage": "इस स्थान की फोटो लेने के लिए कैमरा एक्सेस की अनुमति दें।",
+		"allowCamera": "कैमरा अनुमति दें",
+		"captureButton": "यह क्या है",
+		"custom": "कस्टम",
+		"category": {
+			"must_do": "ज़रूर करें",
+			"history": "इतिहास",
+			"culture": "संस्कृति",
+			"architecture": "वास्तुकला",
+			"food": "भोजन",
+			"nature": "प्रकृति",
+			"people": "लोग",
+			"cost": "खर्च",
+			"safety": "सुरक्षा"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "यह क्या है",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "취소",
+		"ok": "확인",
 		"goStore": "앱 스토어 열기"
 	},
 	"Error": {
 		"maintenanceMessage": "현재 점검 중입니다.",
 		"unsupportedVersion": "이 버전은 더 이상 지원되지 않습니다."
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "장소 검색...",
+		"noResultsFound": "검색 결과가 없습니다",
+		"searchError": "검색에 실패했습니다. 다시 시도해 주세요.",
+		"locationPermissionDenied": "위치 접근이 거부되었습니다. 설정에서 활성화해 주세요.",
+		"locationError": "현재 위치를 확인할 수 없습니다. 다시 시도해 주세요.",
+		"dragToSelect": "지도를 드래그하여 위치를 선택하세요",
+		"searchPlaces": "장소 검색",
+		"selectedLocation": "선택된 위치",
+		"nanicore": "이게 뭐야?"
+	},
+	"PlaceGuide": {
+		"loading": "장소 가이드 로딩 중...",
+		"takePhoto": "사진 찍기",
+		"askQuestion": "이 장소에 대해 질문하기",
+		"askCustomQuestion": "사용자 질문하기",
+		"customQueryPlaceholder": "이 장소에 대해 무엇이 궁금한가요?",
+		"generateGuides": "가이드 생성",
+		"loadError": "가이드를 불러오지 못했습니다. 다시 시도해 주세요.",
+		"generateError": "가이드를 생성하지 못했습니다. 다시 시도해 주세요.",
+		"reactionError": "좋아요 상태 업데이트에 실패했습니다. 다시 시도해 주세요.",
+		"audioError": "오디오 재생에 실패했습니다. 다시 시도해 주세요.",
+		"photoAdded": "사진이 추가되었습니다! 새 이미지를 확인해 보세요.",
+		"guidesGenerated": "가이드가 성공적으로 생성되었습니다!",
+		"cameraNotReady": "카메라가 준비되지 않았습니다",
+		"captureError": "사진 촬영에 실패했습니다. 다시 시도해 주세요.",
+		"cameraPermissionTitle": "카메라 접근",
+		"cameraPermissionMessage": "이 장소의 사진을 찍으려면 카메라 접근을 허용해 주세요.",
+		"allowCamera": "카메라 허용",
+		"captureButton": "이게 뭐야?",
+		"custom": "사용자 정의",
+		"category": {
+			"must_do": "꼭 해야 할 일",
+			"history": "역사",
+			"culture": "문화",
+			"architecture": "건축",
+			"food": "음식",
+			"nature": "자연",
+			"people": "사람들",
+			"cost": "비용",
+			"safety": "안전"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "이게 뭐야?",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -1,11 +1,55 @@
 {
 	"Common": {
 		"cancel": "取消",
+		"ok": "确定",
 		"goStore": "打开应用商店"
 	},
 	"Error": {
 		"maintenanceMessage": "当前正在维护中。",
-		"unsupportedVersion": "此版本已不再受支持。"
+		"unsupportedVersion": "此版本已不再受支持."
+	},
+	"PlaceMapSelect": {
+		"searchPlaceholder": "搜索地点...",
+		"noResultsFound": "未找到相关搜索结果",
+		"searchError": "搜索失败，请重试。",
+		"locationPermissionDenied": "定位权限被拒绝，请在设置中启用。",
+		"locationError": "无法确定您的位置，请重试。",
+		"dragToSelect": "拖动地图选择位置",
+		"searchPlaces": "搜索地点",
+		"selectedLocation": "已选择的位置",
+		"nanicore": "这是什么？"
+	},
+	"PlaceGuide": {
+		"loading": "地点导览加载中...",
+		"takePhoto": "拍照",
+		"askQuestion": "询问此地点",
+		"askCustomQuestion": "自定义提问",
+		"customQueryPlaceholder": "想了解此地点的什么？",
+		"generateGuides": "生成导览",
+		"loadError": "抱歉，无法加载导览，请重试。",
+		"generateError": "抱歉，无法生成导览，请重试。",
+		"reactionError": "更新点赞状态失败，请重试。",
+		"audioError": "音频播放失败，请重试。",
+		"photoAdded": "照片已添加！查看新图片。",
+		"guidesGenerated": "导览生成成功！",
+		"cameraNotReady": "相机未准备好",
+		"captureError": "拍照失败，请重试。",
+		"cameraPermissionTitle": "相机权限",
+		"cameraPermissionMessage": "请允许相机权限以拍摄此地点的照片。",
+		"allowCamera": "允许相机",
+		"captureButton": "这是什么？",
+		"custom": "自定义",
+		"category": {
+			"must_do": "必做事项",
+			"history": "历史",
+			"culture": "文化",
+			"architecture": "建筑",
+			"food": "美食",
+			"nature": "自然",
+			"people": "人文",
+			"cost": "费用",
+			"safety": "安全"
+		}
 	},
 	"SpotCapture": {
 		"captureButton": "这是什么？",


### PR DESCRIPTION
## Summary
- provide complete translations for Arabic, Spanish, French, Hindi, Korean, and Chinese locale files

## Testing
- `pnpm lint` *(fails: network access needed)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c13ed0c34832bace70a45b0caf17a